### PR TITLE
feat: cabinet CRUD with interactions and evidence (#15)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,10 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Landing from './screens/Landing'
 import Chat from './screens/Chat'
 import Cabinet from './screens/Cabinet'
+import CabinetAdd from './screens/CabinetAdd'
+import CabinetDetail from './screens/CabinetDetail'
 import Profile from './screens/Profile'
+import ProtectedRoute from './components/ProtectedRoute'
 
 export default function App() {
   return (
@@ -10,7 +13,9 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/chat" element={<Chat />} />
-        <Route path="/cabinet" element={<Cabinet />} />
+        <Route path="/cabinet" element={<ProtectedRoute><Cabinet /></ProtectedRoute>} />
+        <Route path="/cabinet/add" element={<ProtectedRoute><CabinetAdd /></ProtectedRoute>} />
+        <Route path="/cabinet/:id" element={<ProtectedRoute><CabinetDetail /></ProtectedRoute>} />
         <Route path="/profile" element={<Profile />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom'
+import BottomNav from './BottomNav'
+import Wave from './Wave'
+
+export default function AppShell({ title, backPath, children }) {
+  const navigate = useNavigate()
+
+  const handleBack = () => {
+    if (backPath) {
+      navigate(backPath)
+    } else {
+      navigate(-1)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-page flex flex-col">
+      {/* Top bar */}
+      <div className="bg-orange px-5 pt-12 pb-4 flex items-center gap-3 shrink-0">
+        <button
+          onClick={handleBack}
+          className="w-[36px] h-[36px] rounded-full flex items-center justify-center shrink-0 cursor-pointer"
+          style={{ background: 'rgba(255,255,255,0.2)' }}
+          aria-label="Go back"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <h1 className="text-[17px] font-medium text-white leading-tight truncate">{title}</h1>
+      </div>
+
+      {/* Wave separator */}
+      <div className="-mt-[40px] shrink-0">
+        <Wave />
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto pb-[100px]">
+        {children}
+      </div>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom'
+
+export default function ProtectedRoute({ children }) {
+  const token = localStorage.getItem('token')
+
+  if (!token) {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}

--- a/src/components/SuppCard.jsx
+++ b/src/components/SuppCard.jsx
@@ -6,8 +6,8 @@ const palette = {
   W: { bg: '#FDE8DE', text: '#7A2A1A' },
 }
 
-export default function SuppCard({ letter, name, meta, dose }) {
-  const colors = palette[letter] || palette.C
+export default function SuppCard({ letter, name, meta, dose, colors: colorsProp }) {
+  const colors = colorsProp || palette[letter] || palette.C
 
   return (
     <div className="bg-white rounded-card border border-border px-5 py-[14px] flex items-center gap-[14px] transition-transform hover:translate-x-1">

--- a/src/screens/Cabinet.jsx
+++ b/src/screens/Cabinet.jsx
@@ -1,32 +1,135 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import OrangeHeader from '../components/OrangeHeader'
 import Wave from '../components/Wave'
 import BottomNav from '../components/BottomNav'
 import SuppCard from '../components/SuppCard'
 import FAB from '../components/FAB'
+import { api } from '../services/api'
 
-const supplements = [
-  { letter: 'C', name: 'Purple K Creatine', meta: 'Pre-workout', dose: '3 g' },
-  { letter: 'H', name: 'Ballistic HMB 3.0', meta: 'Post-workout', dose: '1.5 g' },
-  { letter: 'E', name: 'EPA Concentrate', meta: 'With meals', dose: '2 g' },
-  { letter: 'S', name: 'All-In Superfood', meta: 'Morning', dose: '1 scoop' },
-  { letter: 'W', name: 'ISO Whey Gold', meta: 'Post-workout', dose: '30 g' },
+/* ------------------------------------------------------------------ */
+/*  Evidence badge                                                     */
+/* ------------------------------------------------------------------ */
+const EVIDENCE_COLORS = {
+  A: { bg: '#D4ECD8', text: '#2C5A38' },
+  B: { bg: '#DAE8F8', text: '#1A3A6A' },
+  C: { bg: '#FAE8D0', text: '#7A4A1A' },
+  D: { bg: '#FDE8DE', text: '#7A2A1A' },
+}
+
+function EvidenceBadge({ level }) {
+  const colors = EVIDENCE_COLORS[level] || EVIDENCE_COLORS.C
+  return (
+    <span
+      className="rounded-pill px-[8px] py-[2px] text-[10px] font-semibold shrink-0"
+      style={{ background: colors.bg, color: colors.text }}
+    >
+      {level}
+    </span>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Skeleton card                                                      */
+/* ------------------------------------------------------------------ */
+function SkeletonCard() {
+  return (
+    <div className="bg-white rounded-card border border-border px-5 py-[14px] flex items-center gap-[14px] animate-pulse">
+      <div className="w-[40px] h-[40px] rounded-full bg-sand shrink-0" />
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        <div className="h-[14px] w-3/4 bg-sand rounded-pill" />
+        <div className="h-[12px] w-1/2 bg-sand rounded-pill" />
+      </div>
+      <div className="h-[24px] w-[48px] bg-sand rounded-pill shrink-0" />
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Letter avatar color helper                                         */
+/* ------------------------------------------------------------------ */
+const LETTER_PALETTE = [
+  { bg: '#D4ECD8', text: '#2C5A38' },
+  { bg: '#FAE8D0', text: '#7A4A1A' },
+  { bg: '#DAE8F8', text: '#1A3A6A' },
+  { bg: '#E8F4D8', text: '#3A5A1A' },
+  { bg: '#FDE8DE', text: '#7A2A1A' },
+  { bg: '#EDE8F8', text: '#3A1A7A' },
 ]
 
-const stats = [
-  { value: '5', label: 'Active' },
-  { value: '0', label: 'Conflicts' },
-  { value: '14d', label: 'Streak' },
-]
+function getLetterColors(name) {
+  if (!name) return LETTER_PALETTE[0]
+  const idx = name.charCodeAt(0) % LETTER_PALETTE.length
+  return LETTER_PALETTE[idx]
+}
 
+/* ------------------------------------------------------------------ */
+/*  Cabinet screen                                                     */
+/* ------------------------------------------------------------------ */
 export default function Cabinet() {
+  const navigate = useNavigate()
+  const [supplements, setSupplements] = useState([])
+  const [interactions, setInteractions] = useState([])
+  const [evidenceMap, setEvidenceMap] = useState({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
+      try {
+        const [suppRes, interactRes, evidenceRes] = await Promise.allSettled([
+          api.cabinet.list(),
+          api.cabinet.interactions(),
+          api.cabinet.evidenceScores(),
+        ])
+
+        if (suppRes.status === 'fulfilled') {
+          setSupplements(suppRes.value.data || [])
+        } else {
+          setError('Failed to load supplements')
+        }
+
+        if (interactRes.status === 'fulfilled') {
+          setInteractions(interactRes.value.data || [])
+        }
+
+        if (evidenceRes.status === 'fulfilled') {
+          const scores = evidenceRes.value.data || []
+          const map = {}
+          scores.forEach((s) => {
+            if (s.name) map[s.name] = s.evidenceScore
+          })
+          setEvidenceMap(map)
+        }
+      } catch (err) {
+        setError(err.message || 'Failed to load data')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  const filtered = supplements.filter((s) =>
+    s.name.toLowerCase().includes(search.toLowerCase())
+  )
+
+  const stats = [
+    { value: String(supplements.length), label: 'Active' },
+    { value: String(interactions.length), label: 'Conflicts' },
+  ]
+
   return (
     <div className="min-h-screen bg-page">
       {/* Header */}
       <OrangeHeader
         title="Cabinet"
-        subtitle="5 supplements · all active"
-        pill="+ Add"
-        hasStats={true}
+        subtitle={`${supplements.length} supplement${supplements.length !== 1 ? 's' : ''}`}
+        hasStats={!loading}
         stats={stats}
       />
 
@@ -35,10 +138,34 @@ export default function Cabinet() {
         <Wave />
       </div>
 
+      {/* Interaction warning banner */}
+      {interactions.length > 0 && (
+        <div
+          className="mx-5 mb-3 px-4 py-3 rounded-card flex items-start gap-3"
+          style={{ background: '#FEF3C7', border: '1px solid #FCD34D' }}
+        >
+          <svg
+            className="w-[18px] h-[18px] shrink-0 mt-[1px]"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#D97706"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+          <p className="text-[13px] font-medium" style={{ color: '#92400E' }}>
+            {interactions.length} interaction{interactions.length !== 1 ? 's' : ''} detected in your cabinet
+          </p>
+        </div>
+      )}
+
       {/* Search input */}
       <div className="px-5 py-4">
         <div className="relative">
-          {/* Search icon */}
           <svg
             className="absolute left-3 top-1/2 -translate-y-1/2 w-[16px] h-[16px] text-ink3"
             fill="none"
@@ -49,9 +176,10 @@ export default function Cabinet() {
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.35-4.35" strokeLinecap="round" />
           </svg>
-
           <input
             type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
             placeholder="Search supplements..."
             className="w-full bg-white border-[1.5px] border-border-md rounded-pill py-[10px] pr-4 pl-10 text-[11px] text-ink1 placeholder:text-ink4 outline-none"
           />
@@ -60,19 +188,74 @@ export default function Cabinet() {
 
       {/* Supplement card list */}
       <div className="flex flex-col gap-3 px-5 pb-[100px]">
-        {supplements.map((supp) => (
-          <SuppCard
-            key={supp.letter}
-            letter={supp.letter}
-            name={supp.name}
-            meta={supp.meta}
-            dose={supp.dose}
-          />
-        ))}
+        {loading ? (
+          <>
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </>
+        ) : error ? (
+          <div className="text-center py-12">
+            <p className="text-ink3 text-[14px]">{error}</p>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-12">
+            {supplements.length === 0 ? (
+              <>
+                <div className="w-[56px] h-[56px] rounded-full bg-orange-lt flex items-center justify-center mx-auto mb-4">
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#E07B4A"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+                  </svg>
+                </div>
+                <p className="text-ink2 text-[14px] font-medium">Your cabinet is empty.</p>
+                <p className="text-ink3 text-[13px] mt-1">Add your first supplement.</p>
+              </>
+            ) : (
+              <p className="text-ink3 text-[14px]">No supplements match your search.</p>
+            )}
+          </div>
+        ) : (
+          filtered.map((supp) => {
+            const letter = supp.name?.[0]?.toUpperCase() || '?'
+            const colors = getLetterColors(supp.name)
+            const evidenceScore = evidenceMap[supp.name] || supp.evidenceScore
+            const evidenceLevel = evidenceScore?.level
+
+            return (
+              <div
+                key={supp._id}
+                className="relative cursor-pointer"
+                onClick={() => navigate(`/cabinet/${supp._id}`)}
+              >
+                <SuppCard
+                  letter={letter}
+                  name={supp.name}
+                  meta={supp.timing || supp.frequency}
+                  dose={supp.dosage}
+                  colors={colors}
+                />
+                {evidenceLevel && (
+                  <div className="absolute right-[60px] top-1/2 -translate-y-1/2 pointer-events-none">
+                    <EvidenceBadge level={evidenceLevel} />
+                  </div>
+                )}
+              </div>
+            )
+          })
+        )}
       </div>
 
-      {/* FAB */}
-      <FAB />
+      {/* FAB — navigates to add */}
+      <FAB onClick={() => navigate('/cabinet/add')} />
 
       {/* Bottom navigation */}
       <BottomNav />

--- a/src/screens/CabinetAdd.jsx
+++ b/src/screens/CabinetAdd.jsx
@@ -1,0 +1,201 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AppShell from '../components/AppShell'
+import { api } from '../services/api'
+
+const TYPE_OPTIONS = ['Supplement', 'Medication', 'Vitamin', 'Herb', 'Other']
+const FREQUENCY_OPTIONS = ['Daily', 'Twice daily', 'As needed']
+const TIMING_OPTIONS = ['Morning', 'Pre-workout', 'With meals', 'Evening', 'Before bed']
+
+function Field({ label, required, error, children }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-medium text-ink2">
+        {label}
+        {required && <span className="text-orange ml-1">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-[11px] text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+const inputClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors'
+
+const selectClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 outline-none focus:border-orange transition-colors appearance-none cursor-pointer'
+
+export default function CabinetAdd() {
+  const navigate = useNavigate()
+  const [submitting, setSubmitting] = useState(false)
+  const [errors, setErrors] = useState({})
+
+  const [form, setForm] = useState({
+    name: '',
+    type: 'Supplement',
+    dosage: '',
+    frequency: 'Daily',
+    timing: 'Morning',
+    brand: '',
+    notes: '',
+  })
+
+  function handleChange(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function validate() {
+    const newErrors = {}
+    if (!form.name.trim()) newErrors.name = 'Name is required'
+    if (!form.dosage.trim()) newErrors.dosage = 'Dosage is required'
+    return newErrors
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const validationErrors = validate()
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload = {
+        name: form.name.trim(),
+        type: form.type,
+        dosage: form.dosage.trim(),
+        frequency: form.frequency,
+        timing: form.timing,
+        ...(form.brand.trim() ? { brand: form.brand.trim() } : {}),
+        ...(form.notes.trim() ? { notes: form.notes.trim() } : {}),
+      }
+      await api.cabinet.create(payload)
+      navigate('/cabinet')
+    } catch (err) {
+      setErrors({ submit: err.message || 'Failed to add supplement' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AppShell title="Add Supplement" backPath="/cabinet">
+      <form onSubmit={handleSubmit} className="px-5 pt-2 pb-6">
+        {/* Form card */}
+        <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-4">
+
+          <Field label="Name" required error={errors.name}>
+            <input
+              className={inputClass}
+              type="text"
+              value={form.name}
+              onChange={(e) => handleChange('name', e.target.value)}
+              placeholder="e.g. Creatine Monohydrate"
+              autoFocus
+            />
+          </Field>
+
+          <Field label="Type">
+            <div className="relative">
+              <select
+                className={selectClass}
+                value={form.type}
+                onChange={(e) => handleChange('type', e.target.value)}
+              >
+                {TYPE_OPTIONS.map((o) => (
+                  <option key={o} value={o}>{o}</option>
+                ))}
+              </select>
+              <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+          </Field>
+
+          <Field label="Dosage" required error={errors.dosage}>
+            <input
+              className={inputClass}
+              type="text"
+              value={form.dosage}
+              onChange={(e) => handleChange('dosage', e.target.value)}
+              placeholder="e.g. 5g, 1000mg, 2 capsules"
+            />
+          </Field>
+
+          <Field label="Frequency">
+            <div className="relative">
+              <select
+                className={selectClass}
+                value={form.frequency}
+                onChange={(e) => handleChange('frequency', e.target.value)}
+              >
+                {FREQUENCY_OPTIONS.map((o) => (
+                  <option key={o} value={o}>{o}</option>
+                ))}
+              </select>
+              <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+          </Field>
+
+          <Field label="Timing">
+            <div className="relative">
+              <select
+                className={selectClass}
+                value={form.timing}
+                onChange={(e) => handleChange('timing', e.target.value)}
+              >
+                {TIMING_OPTIONS.map((o) => (
+                  <option key={o} value={o}>{o}</option>
+                ))}
+              </select>
+              <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+          </Field>
+
+          <Field label="Brand (optional)">
+            <input
+              className={inputClass}
+              type="text"
+              value={form.brand}
+              onChange={(e) => handleChange('brand', e.target.value)}
+              placeholder="e.g. Optimum Nutrition"
+            />
+          </Field>
+
+          <Field label="Notes (optional)">
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={3}
+              value={form.notes}
+              onChange={(e) => handleChange('notes', e.target.value)}
+              placeholder="Any additional notes..."
+            />
+          </Field>
+        </div>
+
+        {/* Submit error */}
+        {errors.submit && (
+          <p className="text-[13px] text-red-500 text-center mt-4">{errors.submit}</p>
+        )}
+
+        {/* Submit button */}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full mt-5 rounded-pill bg-orange text-white text-[15px] font-medium py-[14px] cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+        >
+          {submitting ? 'Adding...' : 'Add to cabinet'}
+        </button>
+      </form>
+    </AppShell>
+  )
+}

--- a/src/screens/CabinetDetail.jsx
+++ b/src/screens/CabinetDetail.jsx
@@ -1,0 +1,429 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import AppShell from '../components/AppShell'
+import { api } from '../services/api'
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+const TYPE_OPTIONS = ['Supplement', 'Medication', 'Vitamin', 'Herb', 'Other']
+const FREQUENCY_OPTIONS = ['Daily', 'Twice daily', 'As needed']
+const TIMING_OPTIONS = ['Morning', 'Pre-workout', 'With meals', 'Evening', 'Before bed']
+
+const EVIDENCE_COLORS = {
+  A: { bg: '#D4ECD8', text: '#2C5A38', label: 'Strong evidence' },
+  B: { bg: '#DAE8F8', text: '#1A3A6A', label: 'Good evidence' },
+  C: { bg: '#FAE8D0', text: '#7A4A1A', label: 'Moderate evidence' },
+  D: { bg: '#FDE8DE', text: '#7A2A1A', label: 'Limited evidence' },
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+function InfoRow({ label, value }) {
+  if (!value) return null
+  return (
+    <div className="flex items-start justify-between gap-3 py-[10px] border-b border-border last:border-b-0">
+      <span className="text-[12px] text-ink3 shrink-0">{label}</span>
+      <span className="text-[14px] text-ink1 text-right">{value}</span>
+    </div>
+  )
+}
+
+function EditField({ label, required, error, children }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-medium text-ink2">
+        {label}
+        {required && <span className="text-orange ml-1">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-[11px] text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+const inputClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors'
+
+const selectClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 outline-none focus:border-orange transition-colors appearance-none cursor-pointer'
+
+/* ------------------------------------------------------------------ */
+/*  Skeleton                                                           */
+/* ------------------------------------------------------------------ */
+function Skeleton() {
+  return (
+    <div className="px-5 pt-2 animate-pulse flex flex-col gap-4">
+      <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-3">
+        <div className="h-[20px] w-2/3 bg-sand rounded-pill" />
+        <div className="h-[14px] w-1/2 bg-sand rounded-pill" />
+        <div className="h-[14px] w-3/4 bg-sand rounded-pill" />
+        <div className="h-[14px] w-1/3 bg-sand rounded-pill" />
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main screen                                                        */
+/* ------------------------------------------------------------------ */
+export default function CabinetDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const [supp, setSupp] = useState(null)
+  const [interactions, setInteractions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState({})
+  const [formErrors, setFormErrors] = useState({})
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
+      try {
+        const [listRes, interactRes] = await Promise.allSettled([
+          api.cabinet.list(),
+          api.cabinet.interactions(),
+        ])
+
+        if (listRes.status === 'fulfilled') {
+          const items = listRes.value.data || []
+          const found = items.find((s) => s._id === id)
+          if (!found) {
+            setError('Supplement not found')
+          } else {
+            setSupp(found)
+            setForm({
+              name: found.name || '',
+              type: found.type || 'Supplement',
+              dosage: found.dosage || '',
+              frequency: found.frequency || 'Daily',
+              timing: found.timing || 'Morning',
+              brand: found.brand || '',
+              notes: found.notes || '',
+            })
+          }
+        } else {
+          setError('Failed to load supplement')
+        }
+
+        if (interactRes.status === 'fulfilled') {
+          setInteractions(interactRes.value.data || [])
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [id])
+
+  // Interactions that involve this supplement
+  const myInteractions = interactions.filter((ix) =>
+    supp && ix.supplements && ix.supplements.some(
+      (name) => name.toLowerCase() === supp.name.toLowerCase()
+    )
+  )
+
+  function handleChange(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    if (formErrors[field]) {
+      setFormErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function validate() {
+    const errs = {}
+    if (!form.name?.trim()) errs.name = 'Name is required'
+    if (!form.dosage?.trim()) errs.dosage = 'Dosage is required'
+    return errs
+  }
+
+  async function handleSave() {
+    const errs = validate()
+    if (Object.keys(errs).length > 0) {
+      setFormErrors(errs)
+      return
+    }
+
+    setSaving(true)
+    try {
+      const payload = {
+        name: form.name.trim(),
+        type: form.type,
+        dosage: form.dosage.trim(),
+        frequency: form.frequency,
+        timing: form.timing,
+        ...(form.brand?.trim() ? { brand: form.brand.trim() } : {}),
+        ...(form.notes?.trim() ? { notes: form.notes.trim() } : {}),
+      }
+      const res = await api.cabinet.update(id, payload)
+      setSupp(res.data || { ...supp, ...payload })
+      setEditing(false)
+      setFormErrors({})
+    } catch (err) {
+      setFormErrors({ submit: err.message || 'Failed to save changes' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      await api.cabinet.remove(id)
+      navigate('/cabinet')
+    } catch (err) {
+      setFormErrors({ submit: err.message || 'Failed to delete supplement' })
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  const evidenceScore = supp?.evidenceScore
+  const evidenceLevel = evidenceScore?.level
+  const evidenceColors = EVIDENCE_COLORS[evidenceLevel] || null
+
+  return (
+    <AppShell title={supp?.name || 'Supplement'} backPath="/cabinet">
+      {loading ? (
+        <Skeleton />
+      ) : error ? (
+        <div className="px-5 pt-8 text-center">
+          <p className="text-ink3 text-[14px]">{error}</p>
+        </div>
+      ) : editing ? (
+        /* ---------------------------------------------------------------- */
+        /*  Edit mode                                                        */
+        /* ---------------------------------------------------------------- */
+        <div className="px-5 pt-2 pb-6">
+          <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-4">
+
+            <EditField label="Name" required error={formErrors.name}>
+              <input
+                className={inputClass}
+                type="text"
+                value={form.name}
+                onChange={(e) => handleChange('name', e.target.value)}
+              />
+            </EditField>
+
+            <EditField label="Type">
+              <div className="relative">
+                <select
+                  className={selectClass}
+                  value={form.type}
+                  onChange={(e) => handleChange('type', e.target.value)}
+                >
+                  {TYPE_OPTIONS.map((o) => (
+                    <option key={o} value={o}>{o}</option>
+                  ))}
+                </select>
+                <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </div>
+            </EditField>
+
+            <EditField label="Dosage" required error={formErrors.dosage}>
+              <input
+                className={inputClass}
+                type="text"
+                value={form.dosage}
+                onChange={(e) => handleChange('dosage', e.target.value)}
+                placeholder="e.g. 5g, 1000mg, 2 capsules"
+              />
+            </EditField>
+
+            <EditField label="Frequency">
+              <div className="relative">
+                <select
+                  className={selectClass}
+                  value={form.frequency}
+                  onChange={(e) => handleChange('frequency', e.target.value)}
+                >
+                  {FREQUENCY_OPTIONS.map((o) => (
+                    <option key={o} value={o}>{o}</option>
+                  ))}
+                </select>
+                <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </div>
+            </EditField>
+
+            <EditField label="Timing">
+              <div className="relative">
+                <select
+                  className={selectClass}
+                  value={form.timing}
+                  onChange={(e) => handleChange('timing', e.target.value)}
+                >
+                  {TIMING_OPTIONS.map((o) => (
+                    <option key={o} value={o}>{o}</option>
+                  ))}
+                </select>
+                <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </div>
+            </EditField>
+
+            <EditField label="Brand (optional)">
+              <input
+                className={inputClass}
+                type="text"
+                value={form.brand}
+                onChange={(e) => handleChange('brand', e.target.value)}
+              />
+            </EditField>
+
+            <EditField label="Notes (optional)">
+              <textarea
+                className={`${inputClass} resize-none`}
+                rows={3}
+                value={form.notes}
+                onChange={(e) => handleChange('notes', e.target.value)}
+              />
+            </EditField>
+          </div>
+
+          {formErrors.submit && (
+            <p className="text-[13px] text-red-500 text-center mt-4">{formErrors.submit}</p>
+          )}
+
+          <div className="flex gap-3 mt-5">
+            <button
+              onClick={() => { setEditing(false); setFormErrors({}) }}
+              className="flex-1 rounded-pill border-[1.5px] border-border text-ink2 text-[15px] font-medium py-[12px] cursor-pointer hover:border-ink3 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex-1 rounded-pill bg-orange text-white text-[15px] font-medium py-[12px] cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        /* ---------------------------------------------------------------- */
+        /*  Read mode                                                        */
+        /* ---------------------------------------------------------------- */
+        <div className="px-5 pt-2 pb-6 flex flex-col gap-4">
+          {/* Main info card */}
+          <div className="bg-white rounded-card border border-border p-5">
+            <InfoRow label="Type" value={supp.type} />
+            <InfoRow label="Dosage" value={supp.dosage} />
+            <InfoRow label="Frequency" value={supp.frequency} />
+            <InfoRow label="Timing" value={supp.timing} />
+            <InfoRow label="Brand" value={supp.brand} />
+            <InfoRow label="Notes" value={supp.notes} />
+          </div>
+
+          {/* Evidence score card */}
+          {evidenceLevel && (
+            <div
+              className="rounded-card p-5"
+              style={{ background: evidenceColors.bg, border: `1px solid ${evidenceColors.text}22` }}
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <span
+                  className="rounded-pill px-[10px] py-[3px] text-[12px] font-bold"
+                  style={{ background: 'rgba(255,255,255,0.6)', color: evidenceColors.text }}
+                >
+                  Grade {evidenceLevel}
+                </span>
+                <span className="text-[13px] font-medium" style={{ color: evidenceColors.text }}>
+                  {evidenceColors.label}
+                </span>
+              </div>
+              {evidenceScore.rationale && (
+                <p className="text-[13px] leading-relaxed" style={{ color: evidenceColors.text }}>
+                  {evidenceScore.rationale}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Interactions specific to this supplement */}
+          {myInteractions.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] font-semibold text-ink2 uppercase tracking-wide">Interactions</p>
+              {myInteractions.map((ix, i) => (
+                <div
+                  key={i}
+                  className="rounded-card p-4"
+                  style={{ background: '#FEF3C7', border: '1px solid #FCD34D' }}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <svg className="w-[14px] h-[14px] shrink-0" viewBox="0 0 24 24" fill="none" stroke="#D97706" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                      <line x1="12" y1="9" x2="12" y2="13" />
+                      <line x1="12" y1="17" x2="12.01" y2="17" />
+                    </svg>
+                    <span className="text-[12px] font-semibold" style={{ color: '#92400E' }}>
+                      {ix.supplements?.join(' + ')} — {ix.severity}
+                    </span>
+                  </div>
+                  {ix.description && (
+                    <p className="text-[12px] leading-relaxed" style={{ color: '#92400E' }}>
+                      {ix.description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <button
+            onClick={() => setEditing(true)}
+            className="w-full rounded-pill bg-orange text-white text-[15px] font-medium py-[14px] cursor-pointer hover:bg-orange-dk transition-colors"
+          >
+            Edit
+          </button>
+
+          {confirmDelete ? (
+            <div className="rounded-card border border-red-200 bg-red-50 p-4 flex flex-col gap-3">
+              <p className="text-[14px] text-ink1 text-center font-medium">Delete this supplement?</p>
+              <p className="text-[12px] text-ink3 text-center">This action cannot be undone.</p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  className="flex-1 rounded-pill border-[1.5px] border-border text-ink2 text-[14px] font-medium py-[10px] cursor-pointer hover:border-ink3 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="flex-1 rounded-pill bg-red-500 text-white text-[14px] font-medium py-[10px] cursor-pointer disabled:opacity-60 hover:bg-red-600 transition-colors"
+                >
+                  {deleting ? 'Deleting...' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              className="w-full rounded-pill border-[1.5px] border-red-200 text-red-500 text-[15px] font-medium py-[13px] cursor-pointer hover:bg-red-50 transition-colors"
+            >
+              Delete supplement
+            </button>
+          )}
+        </div>
+      )}
+    </AppShell>
+  )
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,34 @@
+const BASE_URL = import.meta.env.VITE_API_URL || 'https://recallth-backend.railway.app'
+
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token')
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(options.headers || {}),
+  }
+
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers,
+  })
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ message: 'Request failed' }))
+    throw new Error(error.message || `HTTP ${res.status}`)
+  }
+
+  return res.json()
+}
+
+export const api = {
+  cabinet: {
+    list: () => request('/cabinet'),
+    create: (data) => request('/cabinet', { method: 'POST', body: JSON.stringify(data) }),
+    update: (id, data) => request(`/cabinet/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    remove: (id) => request(`/cabinet/${id}`, { method: 'DELETE' }),
+    interactions: () => request('/cabinet/interactions'),
+    evidenceScores: () => request('/cabinet/evidence-scores'),
+  },
+}


### PR DESCRIPTION
## What

Full Cabinet CRUD implementation for Recallth mobile app:

- **`src/services/api.js`** — fetch helper with JWT injection + cabinet endpoints (list, create, update, remove, interactions, evidenceScores)
- **`src/screens/Cabinet.jsx`** — updated with real API data, search filter, amber interaction warning banner, evidence grade badges (A/B/C/D), loading skeletons, empty state, FAB navigating to `/cabinet/add`
- **`src/screens/CabinetAdd.jsx`** — form (name, type, dosage, frequency, timing, brand, notes) with inline validation, POST on submit, redirects to `/cabinet`
- **`src/screens/CabinetDetail.jsx`** — read view with evidence grade card + rationale, per-supplement interaction highlights, inline edit mode, delete with confirmation dialog
- **`src/components/AppShell.jsx`** — shared screen shell: orange top bar with back arrow, Wave separator, BottomNav
- **`src/components/ProtectedRoute.jsx`** — JWT guard, redirects unauthenticated users to `/`
- **`src/App.jsx`** — `/cabinet`, `/cabinet/add`, `/cabinet/:id` routes wrapped in `ProtectedRoute`

## Why

Closes #15

## Acceptance Criteria

- [x] List: real data from `GET /cabinet`, client-side search filter, amber conflict banner when interactions exist, evidence badges per card, FAB navigates to `/cabinet/add`
- [x] Add: form with all required fields, inline validation on name/dosage, POST to backend, navigates back to list on success
- [x] Detail: read view showing all fields, evidence grade card with rationale, interaction highlights for this supplement, inline edit mode with Save/Cancel, delete with confirmation
- [x] Loading skeletons on list and detail screens
- [x] Empty state: "Your cabinet is empty. Add your first supplement."

## Test Plan

1. Log in (ensure JWT token is in localStorage under key `token`)
2. Navigate to `/cabinet` — verify loading skeleton shows then supplements load, or empty state if cabinet is empty
3. Tap the FAB (+) — should navigate to `/cabinet/add`
4. Fill in name and dosage, submit — should POST and redirect to `/cabinet` with new item
5. Tap a supplement card — should navigate to `/cabinet/:id` with detail view
6. Tap Edit, change a field, Save — PUT should fire, page returns to read view
7. Tap Delete supplement, confirm — DELETE should fire, navigate back to `/cabinet`
8. If backend returns interactions, verify amber banner shows on list and yellow cards show on detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)