### PR TITLE
feat: Side Effects tracker screen (#39)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import History from './screens/History'
 import Schedule from './screens/Schedule'
 import StackBuilder from './screens/StackBuilder'
 import DoctorPrep from './screens/DoctorPrep'
+import SideEffects from './screens/SideEffects'
 
 // Placeholder screens for routes not yet built
 function Placeholder({ title }) {
@@ -66,6 +67,7 @@ function AppRoutes() {
       <Route path="/stack-builder" element={<ProtectedRoute><StackBuilder /></ProtectedRoute>} />
       <Route path="/doctor-prep"   element={<ProtectedRoute><DoctorPrep /></ProtectedRoute>} />
       <Route path="/history"       element={<ProtectedRoute><History /></ProtectedRoute>} />
+      <Route path="/side-effects"  element={<ProtectedRoute><SideEffects /></ProtectedRoute>} />
 
       {/* Fallback */}
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -9,6 +9,17 @@ export default function BottomNav() {
     { labelKey: 'home', path: '/home' },
     { labelKey: 'chat', path: '/chat' },
     { labelKey: 'cabinet', path: '/cabinet' },
+    {
+      labelKey: 'sideEffects',
+      path: '/side-effects',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+          <line x1="12" y1="9" x2="12" y2="13"/>
+          <line x1="12" y1="17" x2="12.01" y2="17"/>
+        </svg>
+      ),
+    },
     { labelKey: 'profile', path: '/profile' },
   ]
 
@@ -23,7 +34,13 @@ export default function BottomNav() {
             to={tab.path}
             className="flex flex-col items-center gap-1 no-underline"
           >
-            {active ? (
+            {tab.icon ? (
+              <span
+                className={`w-5 h-5 flex items-center justify-center ${active ? 'text-orange' : 'text-ink3'}`}
+              >
+                {tab.icon}
+              </span>
+            ) : active ? (
               <span className="w-5 h-5 rounded-full bg-orange-lt flex items-center justify-center">
                 <span className="w-[6px] h-[6px] rounded-full bg-orange" />
               </span>

--- a/src/components/WebShell.jsx
+++ b/src/components/WebShell.jsx
@@ -66,6 +66,17 @@ const NAV_KEYS = [
     ),
   },
   {
+    to: '/side-effects',
+    key: 'sideEffects',
+    icon: () => (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+        <line x1="12" y1="9" x2="12" y2="13"/>
+        <line x1="12" y1="17" x2="12.01" y2="17"/>
+      </svg>
+    ),
+  },
+  {
     to: '/history',
     key: 'history',
     icon: () => (

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -11,6 +11,7 @@ const TRANSLATIONS = {
     schedule: 'Schedule',
     stackBuilder: 'Stack Builder',
     doctorPrep: 'Doctor Prep',
+    sideEffects: 'Side Effects',
     freePlan: 'Free plan',
     // ── Greetings ────────────────────────────────────────────────────────
     goodMorning: 'Good morning',
@@ -121,6 +122,7 @@ const TRANSLATIONS = {
     schedule: '排程',
     stackBuilder: '堆疊配方',
     doctorPrep: '醫師準備',
+    sideEffects: '副作用',
     freePlan: '免費方案',
     goodMorning: '早安',
     goodAfternoon: '午安',
@@ -221,6 +223,7 @@ const TRANSLATIONS = {
     schedule: '時間表',
     stackBuilder: '配方搭配',
     doctorPrep: '醫生準備',
+    sideEffects: '副作用',
     freePlan: '免費計劃',
     goodMorning: '早晨',
     goodAfternoon: '午安',

--- a/src/screens/SideEffects.jsx
+++ b/src/screens/SideEffects.jsx
@@ -1,0 +1,394 @@
+import { useState, useEffect } from 'react'
+import { api } from '../services/api'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function today() {
+  return new Date().toISOString().split('T')[0]
+}
+
+function relativeDate(dateStr) {
+  if (!dateStr) return ''
+  const now = Date.now()
+  const then = new Date(dateStr).getTime()
+  const diffMs = now - then
+  const diffDay = Math.floor(diffMs / 86400000)
+  if (diffDay === 0) return 'Today'
+  if (diffDay === 1) return 'Yesterday'
+  return `${diffDay} days ago`
+}
+
+const SEVERITY_CONFIG = {
+  mild: {
+    label: 'Mild',
+    badgeClass: 'bg-green-50 text-green-700 border border-green-200',
+    borderColor: '#16a34a',
+    buttonClass: 'bg-green-500 text-white border-green-500',
+    idleClass: 'bg-white text-green-700 border-green-200',
+  },
+  moderate: {
+    label: 'Moderate',
+    badgeClass: 'bg-amber-50 text-amber-700 border border-amber-200',
+    borderColor: '#d97706',
+    buttonClass: 'bg-amber-500 text-white border-amber-500',
+    idleClass: 'bg-white text-amber-700 border-amber-200',
+  },
+  severe: {
+    label: 'Severe',
+    badgeClass: 'bg-red-50 text-red-700 border border-red-200',
+    borderColor: '#dc2626',
+    buttonClass: 'bg-red-500 text-white border-red-500',
+    idleClass: 'bg-white text-red-700 border-red-200',
+  },
+}
+
+// ── Skeleton ─────────────────────────────────────────────────────────────────
+
+function Skeleton({ className = '' }) {
+  return (
+    <div
+      className={`animate-pulse rounded-[10px] bg-gray-100 ${className}`}
+      aria-hidden="true"
+    />
+  )
+}
+
+// ── Severity badge ────────────────────────────────────────────────────────────
+
+function SeverityBadge({ severity }) {
+  const cfg = SEVERITY_CONFIG[severity] ?? SEVERITY_CONFIG.mild
+  return (
+    <span className={`inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium capitalize ${cfg.badgeClass}`}>
+      {cfg.label}
+    </span>
+  )
+}
+
+// ── Timeline card ─────────────────────────────────────────────────────────────
+
+function EntryCard({ entry, onDelete }) {
+  const [confirming, setConfirming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const cfg = SEVERITY_CONFIG[entry.severity] ?? SEVERITY_CONFIG.mild
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      await onDelete(entry._id ?? entry.id)
+    } finally {
+      setDeleting(false)
+      setConfirming(false)
+    }
+  }
+
+  return (
+    <div
+      className="rounded-[14px] border border-border bg-white overflow-hidden flex"
+      role="listitem"
+    >
+      {/* Severity left bar */}
+      <div className="w-1 shrink-0" style={{ background: cfg.borderColor }} />
+
+      <div className="flex-1 min-w-0 px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap mb-1">
+              <span className="text-[12px] text-ink3">{relativeDate(entry.date)}</span>
+              <SeverityBadge severity={entry.severity} />
+            </div>
+            <p className="text-[14px] font-semibold text-ink1 truncate">{entry.supplementName}</p>
+            <p className="text-[13px] text-ink2 mt-[2px]">{entry.effect}</p>
+          </div>
+
+          {/* Delete control */}
+          <div className="shrink-0">
+            {confirming ? (
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] text-ink2">Are you sure?</span>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="text-[12px] font-medium text-red-600 hover:underline disabled:opacity-50 cursor-pointer"
+                >
+                  {deleting ? '…' : 'Yes'}
+                </button>
+                <button
+                  onClick={() => setConfirming(false)}
+                  className="text-[12px] font-medium text-ink3 hover:underline cursor-pointer"
+                >
+                  No
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setConfirming(true)}
+                className="text-ink4 hover:text-red-500 transition-colors cursor-pointer"
+                aria-label="Delete entry"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4h6v2" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Main screen ───────────────────────────────────────────────────────────────
+
+export default function SideEffects() {
+  // ── State ──────────────────────────────────────────────────────────────────
+  const [entries, setEntries] = useState([])
+  const [cabinet, setCabinet] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  // Form fields
+  const [supplementId, setSupplementId] = useState('')
+  const [supplementName, setSupplementName] = useState('')
+  const [effect, setEffect] = useState('')
+  const [severity, setSeverity] = useState('mild')
+  const [date, setDate] = useState(today())
+
+  // ── Fetch on mount ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false
+
+    async function fetchAll() {
+      setLoading(true)
+      try {
+        const [effectsRes, cabinetRes] = await Promise.allSettled([
+          api.sideEffects.list(),
+          api.cabinet.list(),
+        ])
+
+        if (cancelled) return
+
+        if (effectsRes.status === 'fulfilled') {
+          const items = effectsRes.value?.data ?? effectsRes.value ?? []
+          setEntries(Array.isArray(items) ? items : [])
+        }
+
+        if (cabinetRes.status === 'fulfilled') {
+          const items = cabinetRes.value?.data ?? cabinetRes.value ?? []
+          setCabinet(Array.isArray(items) ? items : [])
+        }
+      } catch {
+        // degraded gracefully
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    fetchAll()
+    return () => { cancelled = true }
+  }, [])
+
+  // ── Submit new entry ───────────────────────────────────────────────────────
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const name = cabinet.length > 0 ? (cabinet.find((c) => c._id === supplementId || c.id === supplementId)?.name ?? supplementId) : supplementName
+    if (!name || !effect) return
+
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await api.sideEffects.create({
+        supplementId: supplementId || null,
+        supplementName: name,
+        effect,
+        severity,
+        date,
+      })
+      const newEntry = res?.data ?? res
+      setEntries((prev) => [newEntry, ...prev])
+
+      // Reset form
+      setSupplementId('')
+      setSupplementName('')
+      setEffect('')
+      setSeverity('mild')
+      setDate(today())
+    } catch (err) {
+      setError(err.message ?? 'Failed to log — try again')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Delete entry ───────────────────────────────────────────────────────────
+  async function handleDelete(id) {
+    await api.sideEffects.remove(id)
+    setEntries((prev) => prev.filter((e) => (e._id ?? e.id) !== id))
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="px-5 py-6 md:px-8 md:py-7 max-w-[760px]">
+
+      {/* Page header */}
+      <div className="mb-6">
+        <h1 className="font-display text-[28px] text-ink1 leading-none mb-1">Side Effects</h1>
+        <p className="text-[14px] text-ink2">Track how supplements affect you over time</p>
+      </div>
+
+      {/* ── Log form card ── */}
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-[14px] border border-border bg-white px-5 py-5 mb-7"
+      >
+        <p className="text-[14px] font-semibold text-ink1 mb-4">Log a side effect</p>
+
+        <div className="flex flex-col gap-4">
+
+          {/* Supplement selector or text input */}
+          {cabinet.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] font-medium text-ink2" htmlFor="se-supplement">
+                Supplement
+              </label>
+              <select
+                id="se-supplement"
+                value={supplementId}
+                onChange={(e) => setSupplementId(e.target.value)}
+                required
+                className="w-full rounded-[10px] border border-border bg-white px-3 py-[9px] text-[13px] text-ink1 outline-none focus:border-orange transition-colors appearance-none cursor-pointer"
+              >
+                <option value="" disabled>Select supplement…</option>
+                {cabinet.map((item) => (
+                  <option key={item._id ?? item.id} value={item._id ?? item.id}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] font-medium text-ink2" htmlFor="se-supplement-name">
+                Supplement
+              </label>
+              <input
+                id="se-supplement-name"
+                type="text"
+                value={supplementName}
+                onChange={(e) => setSupplementName(e.target.value)}
+                placeholder="Supplement name"
+                required
+                className="w-full rounded-[10px] border border-border bg-white px-3 py-[9px] text-[13px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors"
+              />
+            </div>
+          )}
+
+          {/* Effect description */}
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] font-medium text-ink2" htmlFor="se-effect">
+              What did you notice?
+            </label>
+            <input
+              id="se-effect"
+              type="text"
+              value={effect}
+              onChange={(e) => setEffect(e.target.value)}
+              placeholder="What did you notice?"
+              required
+              className="w-full rounded-[10px] border border-border bg-white px-3 py-[9px] text-[13px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors"
+            />
+          </div>
+
+          {/* Severity picker */}
+          <div className="flex flex-col gap-2">
+            <span className="text-[12px] font-medium text-ink2">Severity</span>
+            <div className="flex gap-2" role="radiogroup" aria-label="Severity">
+              {(['mild', 'moderate', 'severe']).map((s) => {
+                const cfg = SEVERITY_CONFIG[s]
+                const selected = severity === s
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    onClick={() => setSeverity(s)}
+                    className={`flex-1 py-[8px] rounded-[10px] border text-[13px] font-medium transition-colors cursor-pointer ${
+                      selected ? cfg.buttonClass : cfg.idleClass + ' border'
+                    }`}
+                  >
+                    {cfg.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Date */}
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] font-medium text-ink2" htmlFor="se-date">
+              Date
+            </label>
+            <input
+              id="se-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              max={today()}
+              required
+              className="w-full rounded-[10px] border border-border bg-white px-3 py-[9px] text-[13px] text-ink1 outline-none focus:border-orange transition-colors"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-[13px] text-red-600" role="alert">{error}</p>
+          )}
+
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full py-[10px] rounded-[10px] bg-orange text-white text-[14px] font-semibold transition-opacity disabled:opacity-60 cursor-pointer hover:opacity-90"
+          >
+            {submitting ? 'Logging…' : 'Log Effect'}
+          </button>
+        </div>
+      </form>
+
+      {/* ── Timeline ── */}
+      <div>
+        <h2 className="text-[15px] font-semibold text-ink1 mb-4">History</h2>
+
+        {loading ? (
+          <div className="flex flex-col gap-3" aria-label="Loading">
+            <Skeleton className="h-[88px]" />
+            <Skeleton className="h-[88px]" />
+            <Skeleton className="h-[88px]" />
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="rounded-[14px] border border-border bg-white px-6 py-10 text-center">
+            <p className="text-[13px] text-ink2">
+              No side effects logged — track how supplements affect you
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3" role="list">
+            {entries.map((entry) => (
+              <EntryCard
+                key={entry._id ?? entry.id}
+                entry={entry}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+    </div>
+  )
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -54,4 +54,9 @@ export const api = {
     get: () => request('/profile'),
     update: (data) => request('/profile', { method: 'PUT', body: JSON.stringify(data) }),
   },
+  sideEffects: {
+    list: () => request('/side-effects'),
+    create: (data) => request('/side-effects', { method: 'POST', body: JSON.stringify(data) }),
+    remove: (id) => request(`/side-effects/${id}`, { method: 'DELETE' }),
+  },
 }


### PR DESCRIPTION
## What
Built the Side Effects tracker screen, wiring it into navigation and routing.

- `src/screens/SideEffects.jsx` — new screen with log form + reverse-chrono timeline
- `src/App.jsx` — import + protected route `/side-effects`
- `src/components/WebShell.jsx` — Side Effects nav link with warning triangle icon
- `src/components/BottomNav.jsx` — Side Effects tab with icon
- `src/services/api.js` — `api.sideEffects` namespace (list / create / remove)
- `src/context/LanguageContext.jsx` — `sideEffects` translation key for en / zh-TW / zh-HK

## Why
Closes #39

## Acceptance Criteria
- [x] Fetches side effects list and cabinet in parallel on mount
- [x] Log form: supplement selector (cabinet items) or text fallback when cabinet empty
- [x] Effect description text input
- [x] Severity: Mild / Moderate / Severe radio-style buttons with green/amber/red filled state
- [x] Date input defaulting to today
- [x] Submit calls `api.sideEffects.create`, prepends new entry to list
- [x] Timeline entries in reverse chrono order with coloured left border
- [x] Per-card inline delete with "Are you sure? Yes / No" confirmation
- [x] Severity badge chips (green/amber/red)
- [x] Loading state: 3 skeleton cards
- [x] Empty state: descriptive message
- [x] Design system: orange/sand palette, `rounded-[14px] border border-border bg-white` cards
- [x] WebShell sidebar nav link added
- [x] BottomNav tab added

## Test Plan
1. Log in and navigate to `/side-effects`
2. With an empty cabinet: verify text input appears for supplement name
3. Add a supplement to cabinet, return to Side Effects: verify select dropdown appears
4. Fill form → click "Log Effect" → entry appears at top of timeline
5. Click trash icon → confirm "Are you sure?" → click Yes → entry removed
6. Click trash icon → click No → entry remains
7. Reload page — entries persist (API backed)
8. Verify skeleton cards appear briefly while loading
9. On a fresh account with no entries, verify empty state message shows