### PR TITLE
feat: wire Nutrition Tracker routes and nav (#63)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,9 @@ import Progress from './screens/Progress'
 import Goals from './screens/Goals'
 import Notifications from './screens/Notifications'
 import Bloodwork from './screens/Bloodwork'
+import NutritionTracker from './screens/NutritionTracker'
+import NutritionAdd from './screens/NutritionAdd'
+import NutritionDetail from './screens/NutritionDetail'
 
 // Placeholder screens for routes not yet built
 function Placeholder({ title }) {
@@ -79,6 +82,9 @@ function AppRoutes() {
       <Route path="/goals"          element={<ProtectedRoute><Goals /></ProtectedRoute>} />
       <Route path="/bloodwork"     element={<ProtectedRoute><Bloodwork /></ProtectedRoute>} />
       <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
+      <Route path="/nutrition"     element={<ProtectedRoute><NutritionTracker /></ProtectedRoute>} />
+      <Route path="/nutrition/add" element={<ProtectedRoute><NutritionAdd /></ProtectedRoute>} />
+      <Route path="/nutrition/:id" element={<ProtectedRoute><NutritionDetail /></ProtectedRoute>} />
 
       {/* Fallback */}
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/WebShell.jsx
+++ b/src/components/WebShell.jsx
@@ -36,6 +36,18 @@ const NAV_KEYS = [
     ),
   },
   {
+    to: '/nutrition',
+    key: 'nutrition',
+    icon: () => (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2a9 9 0 0 1 9 9H3a9 9 0 0 1 9-9z"/>
+        <path d="M3 11h18"/>
+        <path d="M5 11v8a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-8"/>
+        <path d="M12 2v9"/>
+      </svg>
+    ),
+  },
+  {
     to: '/schedule',
     key: 'schedule',
     icon: () => (

--- a/src/screens/NutritionAdd.jsx
+++ b/src/screens/NutritionAdd.jsx
@@ -1,0 +1,406 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import OrangeHeader from '../components/OrangeHeader'
+import Wave from '../components/Wave'
+import { api } from '../services/api'
+import { useLanguage } from '../context/LanguageContext'
+
+const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack']
+
+const MEAL_TRANSLATION_KEYS = {
+  breakfast: 'nutritionMealBreakfast',
+  lunch: 'nutritionMealLunch',
+  dinner: 'nutritionMealDinner',
+  snack: 'nutritionMealSnack',
+}
+
+function todayISO() {
+  const d = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+function Field({ label, required, error, children }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-medium text-ink2">
+        {label}
+        {required && <span className="text-orange ml-1">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-[11px] text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+const inputClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors'
+
+const selectClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 outline-none focus:border-orange transition-colors appearance-none cursor-pointer'
+
+export default function NutritionAdd() {
+  const navigate = useNavigate()
+  const { t } = useLanguage()
+
+  // ── Form state ───────────────────────────────────────────────────────
+  const [form, setForm] = useState({
+    foodName: '',
+    mealType: 'breakfast',
+    quantity: '',
+    calories: '',
+    protein: '',
+    carbs: '',
+    fat: '',
+    notes: '',
+  })
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
+
+  // ── AI panel state ───────────────────────────────────────────────────
+  const [aiText, setAiText] = useState('')
+  const [aiParsing, setAiParsing] = useState(false)
+  const [aiResults, setAiResults] = useState([])
+  const [aiSelectedIndex, setAiSelectedIndex] = useState(null)
+  const [aiError, setAiError] = useState(null)
+  const [aiPanelOpen, setAiPanelOpen] = useState(true)
+
+  function handleChange(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  // ── AI parse ─────────────────────────────────────────────────────────
+  async function handleAiParse(e) {
+    e.preventDefault()
+    if (!aiText.trim()) return
+    setAiParsing(true)
+    setAiResults([])
+    setAiSelectedIndex(null)
+    setAiError(null)
+    try {
+      const res = await api.nutrition.aiParse(aiText.trim())
+      const items = res?.data ?? res ?? []
+      const parsed = Array.isArray(items) ? items : []
+      setAiResults(parsed)
+      if (parsed.length === 0) {
+        setAiError('No foods found. Try describing your meal differently.')
+      }
+    } catch (err) {
+      setAiError(err.message || 'Failed to parse — please try again.')
+    } finally {
+      setAiParsing(false)
+    }
+  }
+
+  function handleAiUse() {
+    if (aiSelectedIndex === null || !aiResults[aiSelectedIndex]) return
+    const item = aiResults[aiSelectedIndex]
+    setForm((prev) => ({
+      ...prev,
+      foodName: item.name ?? prev.foodName,
+      quantity: item.quantity ?? item.serving ?? prev.quantity,
+      calories: item.nutrients?.calories ?? item.calories ?? prev.calories,
+      protein: item.nutrients?.protein ?? item.protein ?? prev.protein,
+      carbs: item.nutrients?.carbs ?? item.carbs ?? prev.carbs,
+      fat: item.nutrients?.fat ?? item.fat ?? prev.fat,
+    }))
+    setErrors((prev) => ({ ...prev, foodName: undefined }))
+    setAiPanelOpen(false)
+  }
+
+  // ── Validation ───────────────────────────────────────────────────────
+  function validate() {
+    const newErrors = {}
+    if (!form.foodName.trim()) newErrors.foodName = `${t('nutritionFieldFood')} is required`
+    return newErrors
+  }
+
+  // ── Submit ───────────────────────────────────────────────────────────
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const validationErrors = validate()
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload = {
+        date: todayISO(),
+        mealType: form.mealType,
+        foods: [
+          {
+            name: form.foodName.trim(),
+            quantity: form.quantity.trim(),
+            nutrients: {
+              calories: form.calories === '' ? undefined : Number(form.calories),
+              protein: form.protein === '' ? undefined : Number(form.protein),
+              carbs: form.carbs === '' ? undefined : Number(form.carbs),
+              fat: form.fat === '' ? undefined : Number(form.fat),
+            },
+          },
+        ],
+        ...(form.notes.trim() ? { notes: form.notes.trim() } : {}),
+      }
+      await api.nutrition.create(payload)
+      navigate(-1)
+    } catch (err) {
+      setErrors({ submit: err.message || 'Failed to save — please try again.' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-page">
+      <OrangeHeader
+        title={t('nutritionAddTitle')}
+        onBack={() => navigate(-1)}
+      />
+
+      <div className="-mt-[40px]">
+        <Wave />
+      </div>
+
+      <form onSubmit={handleSubmit} className="px-5 pt-2 pb-[100px] flex flex-col gap-3">
+
+        {/* ── AI auto-fill panel ─────────────────────────────────────── */}
+        <div className="bg-white rounded-card border border-border overflow-hidden">
+          {/* Panel header / toggle */}
+          <button
+            type="button"
+            onClick={() => setAiPanelOpen((v) => !v)}
+            className="w-full flex items-center justify-between px-5 py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-orange"
+            aria-expanded={aiPanelOpen}
+          >
+            <div className="flex items-center gap-2">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-orange">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              <span className="text-[13px] font-semibold text-ink1">AI Auto-fill</span>
+            </div>
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              className={`text-ink3 transition-transform ${aiPanelOpen ? 'rotate-180' : ''}`}
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+
+          {aiPanelOpen && (
+            <div className="px-5 pb-5 flex flex-col gap-3 border-t border-border">
+              {/* AI text input */}
+              <div className="flex gap-2 pt-3">
+                <input
+                  className={`${inputClass} flex-1`}
+                  type="text"
+                  value={aiText}
+                  onChange={(e) => setAiText(e.target.value)}
+                  placeholder={t('nutritionAiPlaceholder')}
+                  disabled={aiParsing}
+                  aria-label={t('nutritionAiPlaceholder')}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleAiParse(e) }}
+                />
+                <button
+                  type="button"
+                  onClick={handleAiParse}
+                  disabled={aiParsing || !aiText.trim()}
+                  className="shrink-0 rounded-[12px] bg-orange text-white text-[13px] font-medium px-4 py-[10px] cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+                >
+                  {aiParsing ? (
+                    <svg className="animate-spin w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M21 12a9 9 0 1 1-6.219-8.56" strokeLinecap="round" />
+                    </svg>
+                  ) : (
+                    'Parse'
+                  )}
+                </button>
+              </div>
+
+              {/* AI error */}
+              {aiError && (
+                <p className="text-[12px] text-red-500">{aiError}</p>
+              )}
+
+              {/* AI results list */}
+              {aiResults.length > 0 && (
+                <div className="flex flex-col gap-2">
+                  <p className="text-[12px] text-ink2 font-medium">
+                    {t('nutritionAiParsed').replace('{n}', aiResults.length)}
+                  </p>
+                  <div className="flex flex-col gap-2">
+                    {aiResults.map((item, idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        onClick={() => setAiSelectedIndex(idx)}
+                        aria-pressed={aiSelectedIndex === idx}
+                        className={`w-full text-left rounded-[12px] border px-4 py-3 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange ${
+                          aiSelectedIndex === idx
+                            ? 'border-orange bg-orange/5'
+                            : 'border-border bg-page hover:border-orange/40'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-[14px] font-medium text-ink1">{item.name}</span>
+                          {(item.nutrients?.calories ?? item.calories) !== undefined && (
+                            <span className="text-[12px] text-ink3 shrink-0">
+                              {item.nutrients?.calories ?? item.calories} kcal
+                            </span>
+                          )}
+                        </div>
+                        {(item.quantity ?? item.serving) && (
+                          <span className="text-[12px] text-ink3">
+                            {item.quantity ?? item.serving}
+                          </span>
+                        )}
+                        {(item.nutrients || item.protein !== undefined) && (
+                          <div className="flex gap-3 mt-1">
+                            {(item.nutrients?.protein ?? item.protein) !== undefined && (
+                              <span className="text-[11px] text-ink3">P {item.nutrients?.protein ?? item.protein}g</span>
+                            )}
+                            {(item.nutrients?.carbs ?? item.carbs) !== undefined && (
+                              <span className="text-[11px] text-ink3">C {item.nutrients?.carbs ?? item.carbs}g</span>
+                            )}
+                            {(item.nutrients?.fat ?? item.fat) !== undefined && (
+                              <span className="text-[11px] text-ink3">F {item.nutrients?.fat ?? item.fat}g</span>
+                            )}
+                          </div>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={handleAiUse}
+                    disabled={aiSelectedIndex === null}
+                    className="w-full rounded-[12px] bg-orange text-white text-[13px] font-medium py-[10px] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+                  >
+                    Use this
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Manual form ───────────────────────────────────────────── */}
+        <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-4">
+
+          <Field label={t('nutritionFieldFood')} required error={errors.foodName}>
+            <input
+              className={inputClass}
+              type="text"
+              value={form.foodName}
+              onChange={(e) => handleChange('foodName', e.target.value)}
+              placeholder="e.g. Grilled chicken, Apple"
+              autoFocus
+            />
+          </Field>
+
+          <Field label={t('nutritionFieldMeal')}>
+            <div className="relative">
+              <select
+                className={selectClass}
+                value={form.mealType}
+                onChange={(e) => handleChange('mealType', e.target.value)}
+              >
+                {MEAL_TYPES.map((mt) => (
+                  <option key={mt} value={mt}>
+                    {t(MEAL_TRANSLATION_KEYS[mt])}
+                  </option>
+                ))}
+              </select>
+              <svg className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+          </Field>
+
+          <Field label={t('nutritionFieldQuantity')}>
+            <input
+              className={inputClass}
+              type="text"
+              value={form.quantity}
+              onChange={(e) => handleChange('quantity', e.target.value)}
+              placeholder="e.g. 1 plate, 250g"
+            />
+          </Field>
+
+          <Field label={`${t('nutritionCalories')} (kcal)`}>
+            <input
+              className={inputClass}
+              type="number"
+              min="0"
+              value={form.calories}
+              onChange={(e) => handleChange('calories', e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+
+          <Field label={`${t('nutritionProtein')} (g)`}>
+            <input
+              className={inputClass}
+              type="number"
+              min="0"
+              value={form.protein}
+              onChange={(e) => handleChange('protein', e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+
+          <Field label={`${t('nutritionCarbs')} (g)`}>
+            <input
+              className={inputClass}
+              type="number"
+              min="0"
+              value={form.carbs}
+              onChange={(e) => handleChange('carbs', e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+
+          <Field label={`${t('nutritionFat')} (g)`}>
+            <input
+              className={inputClass}
+              type="number"
+              min="0"
+              value={form.fat}
+              onChange={(e) => handleChange('fat', e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+
+          <Field label={t('fieldNotes')}>
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={3}
+              value={form.notes}
+              onChange={(e) => handleChange('notes', e.target.value)}
+              placeholder="Any additional notes..."
+            />
+          </Field>
+        </div>
+
+        {errors.submit && (
+          <p className="text-[13px] text-red-500 text-center mt-2">{errors.submit}</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full mt-5 rounded-pill bg-orange text-white text-[15px] font-medium py-[14px] cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+        >
+          {submitting ? t('adding') : t('nutritionConfirm')}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/screens/NutritionDetail.jsx
+++ b/src/screens/NutritionDetail.jsx
@@ -1,0 +1,475 @@
+import { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import OrangeHeader from '../components/OrangeHeader'
+import Wave from '../components/Wave'
+import { api } from '../services/api'
+import { useLanguage } from '../context/LanguageContext'
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+const MEAL_OPTIONS = ['Breakfast', 'Lunch', 'Dinner', 'Snack']
+
+const MEAL_COLORS = {
+  Breakfast: { bg: '#E8EEFF', text: '#3D5BA0' },
+  Lunch:     { bg: '#E8F0E8', text: '#3D6B3D' },
+  Dinner:    { bg: '#FDE8DE', text: '#C05A28' },
+  Snack:     { bg: '#F5F0E8', text: '#7A6030' },
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+function relativeTime(dateStr) {
+  if (!dateStr) return ''
+  const now = Date.now()
+  const then = new Date(dateStr).getTime()
+  const diffMs = now - then
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 60) return `${diffMin || 1} min ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr} hour${diffHr > 1 ? 's' : ''} ago`
+  const diffDay = Math.floor(diffHr / 24)
+  if (diffDay === 1) return 'Yesterday'
+  return `${diffDay} days ago`
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+function NutrientPill({ label, value, colorClass }) {
+  if (value === undefined || value === null || value === '') return null
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-pill px-[10px] py-[4px] text-[12px] font-medium ${colorClass}`}>
+      {label}: {value}
+    </span>
+  )
+}
+
+function EditField({ label, required, error, children }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-medium text-ink2">
+        {label}
+        {required && <span className="text-orange ml-1">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-[11px] text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+const inputClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 placeholder:text-ink4 outline-none focus:border-orange transition-colors'
+
+const selectClass =
+  'w-full bg-page border-[1.5px] border-border rounded-[12px] px-4 py-[10px] text-[14px] text-ink1 outline-none focus:border-orange transition-colors appearance-none cursor-pointer'
+
+/* ------------------------------------------------------------------ */
+/*  Skeleton                                                           */
+/* ------------------------------------------------------------------ */
+function Skeleton() {
+  return (
+    <div className="px-5 pt-2 animate-pulse flex flex-col gap-4">
+      <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-3">
+        <div className="h-[22px] w-2/3 bg-sand rounded-pill" />
+        <div className="flex gap-2">
+          <div className="h-[24px] w-[70px] bg-sand rounded-pill" />
+          <div className="h-[24px] w-[70px] bg-sand rounded-pill" />
+          <div className="h-[24px] w-[70px] bg-sand rounded-pill" />
+        </div>
+        <div className="h-[14px] w-1/2 bg-sand rounded-pill" />
+        <div className="h-[14px] w-3/4 bg-sand rounded-pill" />
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main screen                                                        */
+/* ------------------------------------------------------------------ */
+export default function NutritionDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { t } = useLanguage()
+
+  const [entry, setEntry] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState({})
+  const [formErrors, setFormErrors] = useState({})
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const confirmTimeoutRef = useRef(null)
+
+  useEffect(() => {
+    async function fetchEntry() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await api.nutrition.get(id)
+        const data = res?.data ?? res
+        if (!data) {
+          setError('Entry not found')
+        } else {
+          setEntry(data)
+          setForm({
+            name:     data.name     || '',
+            mealType: data.mealType || 'Breakfast',
+            quantity: data.quantity || '',
+            calories: data.calories !== undefined ? String(data.calories) : '',
+            protein:  data.protein  !== undefined ? String(data.protein)  : '',
+            carbs:    data.carbs    !== undefined ? String(data.carbs)    : '',
+            fat:      data.fat      !== undefined ? String(data.fat)      : '',
+            notes:    data.notes    || '',
+          })
+        }
+      } catch {
+        setError('Failed to load entry')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchEntry()
+  }, [id])
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+    }
+  }, [])
+
+  function handleChange(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    if (formErrors[field]) {
+      setFormErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function validate() {
+    const errs = {}
+    if (!form.name?.trim()) errs.name = 'Food name is required'
+    return errs
+  }
+
+  async function handleSave() {
+    const errs = validate()
+    if (Object.keys(errs).length > 0) {
+      setFormErrors(errs)
+      return
+    }
+
+    setSaving(true)
+    try {
+      const payload = {
+        name:     form.name.trim(),
+        mealType: form.mealType,
+        ...(form.quantity?.trim()                  ? { quantity: form.quantity.trim() }     : {}),
+        ...(form.calories !== '' ? { calories: Number(form.calories) } : {}),
+        ...(form.protein  !== '' ? { protein:  Number(form.protein)  } : {}),
+        ...(form.carbs    !== '' ? { carbs:    Number(form.carbs)    } : {}),
+        ...(form.fat      !== '' ? { fat:      Number(form.fat)      } : {}),
+        ...(form.notes?.trim()                     ? { notes: form.notes.trim() }           : {}),
+      }
+      const res = await api.nutrition.update(id, payload)
+      const updated = res?.data ?? res
+      setEntry((prev) => ({ ...prev, ...updated }))
+      setEditing(false)
+      setFormErrors({})
+    } catch (err) {
+      setFormErrors({ submit: err.message || 'Failed to save changes' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleDeleteFirstTap() {
+    setConfirmDelete(true)
+    confirmTimeoutRef.current = setTimeout(() => {
+      setConfirmDelete(false)
+    }, 3000)
+  }
+
+  async function handleDelete() {
+    if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+    setDeleting(true)
+    try {
+      await api.nutrition.remove(id)
+      navigate('/nutrition')
+    } catch (err) {
+      setFormErrors({ submit: err.message || 'Failed to delete entry' })
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  const mealColors = MEAL_COLORS[entry?.mealType] || MEAL_COLORS.Snack
+
+  return (
+    <div className="min-h-screen bg-page">
+      <OrangeHeader
+        title={t('nutritionAddTitle')}
+        onBack={() => navigate('/nutrition')}
+      />
+
+      <div className="-mt-[40px]">
+        <Wave />
+      </div>
+
+      {loading ? (
+        <div className="px-5 pt-2">
+          <Skeleton />
+        </div>
+      ) : error ? (
+        <div className="px-5 pt-8 text-center">
+          <p className="text-ink3 text-[14px]">{error}</p>
+        </div>
+      ) : editing ? (
+        /* ── Edit mode ─────────────────────────────────────────────── */
+        <div className="px-5 pt-2 pb-[100px]">
+          <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-4">
+
+            <EditField label={t('nutritionFieldFood')} required error={formErrors.name}>
+              <input
+                className={inputClass}
+                type="text"
+                value={form.name}
+                onChange={(e) => handleChange('name', e.target.value)}
+                placeholder="e.g. Grilled chicken"
+              />
+            </EditField>
+
+            <EditField label={t('nutritionFieldMeal')}>
+              <div className="relative">
+                <select
+                  className={selectClass}
+                  value={form.mealType}
+                  onChange={(e) => handleChange('mealType', e.target.value)}
+                >
+                  {MEAL_OPTIONS.map((o) => (
+                    <option key={o} value={o}>{o}</option>
+                  ))}
+                </select>
+                <svg
+                  className="absolute right-3 top-1/2 -translate-y-1/2 w-[14px] h-[14px] text-ink3 pointer-events-none"
+                  fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </div>
+            </EditField>
+
+            <EditField label={t('nutritionFieldQuantity')}>
+              <input
+                className={inputClass}
+                type="text"
+                value={form.quantity}
+                onChange={(e) => handleChange('quantity', e.target.value)}
+                placeholder="e.g. 150g, 1 cup"
+              />
+            </EditField>
+
+            <EditField label={t('nutritionCalories')}>
+              <input
+                className={inputClass}
+                type="number"
+                min="0"
+                value={form.calories}
+                onChange={(e) => handleChange('calories', e.target.value)}
+                placeholder="kcal"
+              />
+            </EditField>
+
+            <EditField label={t('nutritionProtein')}>
+              <input
+                className={inputClass}
+                type="number"
+                min="0"
+                value={form.protein}
+                onChange={(e) => handleChange('protein', e.target.value)}
+                placeholder="g"
+              />
+            </EditField>
+
+            <EditField label={t('nutritionCarbs')}>
+              <input
+                className={inputClass}
+                type="number"
+                min="0"
+                value={form.carbs}
+                onChange={(e) => handleChange('carbs', e.target.value)}
+                placeholder="g"
+              />
+            </EditField>
+
+            <EditField label={t('nutritionFat')}>
+              <input
+                className={inputClass}
+                type="number"
+                min="0"
+                value={form.fat}
+                onChange={(e) => handleChange('fat', e.target.value)}
+                placeholder="g"
+              />
+            </EditField>
+
+            <EditField label={t('fieldNotes')}>
+              <textarea
+                className={`${inputClass} resize-none`}
+                rows={3}
+                value={form.notes}
+                onChange={(e) => handleChange('notes', e.target.value)}
+              />
+            </EditField>
+          </div>
+
+          {formErrors.submit && (
+            <p className="text-[13px] text-red-500 text-center mt-4">{formErrors.submit}</p>
+          )}
+
+          <div className="flex gap-3 mt-5">
+            <button
+              onClick={() => { setEditing(false); setFormErrors({}) }}
+              className="flex-1 rounded-pill border-[1.5px] border-border text-ink2 text-[15px] font-medium py-[12px] cursor-pointer hover:border-ink3 transition-colors"
+            >
+              {t('cancelButton')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex-1 rounded-pill bg-orange text-white text-[15px] font-medium py-[12px] cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed hover:bg-orange-dk transition-colors"
+            >
+              {saving ? t('saving') : t('saveButton')}
+            </button>
+          </div>
+        </div>
+      ) : (
+        /* ── Read mode ─────────────────────────────────────────────── */
+        <div className="px-5 pt-2 pb-[100px] flex flex-col gap-4">
+          <div className="bg-white rounded-card border border-border p-5 flex flex-col gap-4">
+
+            {/* Food name */}
+            <h2 className="font-display text-[22px] text-ink1 leading-tight">
+              {entry.name}
+            </h2>
+
+            {/* Meal type badge */}
+            {entry.mealType && (
+              <span
+                className="self-start rounded-pill px-[12px] py-[4px] text-[12px] font-semibold"
+                style={{ background: mealColors.bg, color: mealColors.text }}
+              >
+                {entry.mealType}
+              </span>
+            )}
+
+            {/* Nutrient pills */}
+            {(entry.calories !== undefined || entry.protein !== undefined ||
+              entry.carbs !== undefined || entry.fat !== undefined) && (
+              <div className="flex flex-wrap gap-2">
+                <NutrientPill
+                  label={t('nutritionCalories')}
+                  value={entry.calories !== undefined ? `${entry.calories} kcal` : undefined}
+                  colorClass="bg-[#FDE8DE] text-[#C05A28]"
+                />
+                <NutrientPill
+                  label={t('nutritionProtein')}
+                  value={entry.protein !== undefined ? `${entry.protein}g` : undefined}
+                  colorClass="bg-[#E8F0E8] text-[#3D6B3D]"
+                />
+                <NutrientPill
+                  label={t('nutritionCarbs')}
+                  value={entry.carbs !== undefined ? `${entry.carbs}g` : undefined}
+                  colorClass="bg-[#E8EEFF] text-[#3D5BA0]"
+                />
+                <NutrientPill
+                  label={t('nutritionFat')}
+                  value={entry.fat !== undefined ? `${entry.fat}g` : undefined}
+                  colorClass="bg-sand text-ink2"
+                />
+              </div>
+            )}
+
+            {/* Quantity */}
+            {entry.quantity && (
+              <div className="flex items-start justify-between gap-3 py-[10px] border-t border-border">
+                <span className="text-[12px] text-ink3 shrink-0">{t('nutritionFieldQuantity')}</span>
+                <span className="text-[14px] text-ink1 text-right">{entry.quantity}</span>
+              </div>
+            )}
+
+            {/* Notes */}
+            {entry.notes && (
+              <div className="flex flex-col gap-1 py-[10px] border-t border-border">
+                <span className="text-[12px] text-ink3">{t('fieldNotes')}</span>
+                <span className="text-[14px] text-ink1 leading-relaxed">{entry.notes}</span>
+              </div>
+            )}
+
+            {/* Raw input text */}
+            {entry.rawInput && (
+              <p className="text-[13px] text-ink3 italic border-t border-border pt-[10px]">
+                You said: &ldquo;{entry.rawInput}&rdquo;
+              </p>
+            )}
+
+            {/* Timestamp */}
+            {entry.createdAt && (
+              <p className="text-[11px] text-ink4 border-t border-border pt-[10px]">
+                {relativeTime(entry.createdAt)}
+              </p>
+            )}
+          </div>
+
+          {/* Edit button */}
+          <button
+            onClick={() => setEditing(true)}
+            className="w-full rounded-pill bg-orange text-white text-[15px] font-medium py-[14px] cursor-pointer hover:bg-orange-dk transition-colors"
+          >
+            {t('editButton')}
+          </button>
+
+          {/* Delete — two-step confirmation */}
+          {confirmDelete ? (
+            <div className="rounded-card border border-red-200 bg-red-50 p-4 flex flex-col gap-3">
+              <p className="text-[14px] text-ink1 text-center font-medium">
+                {t('nutritionDeleteConfirm')}
+              </p>
+              <p className="text-[12px] text-ink3 text-center">{t('cannotUndo')}</p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => {
+                    if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+                    setConfirmDelete(false)
+                  }}
+                  className="flex-1 rounded-pill border-[1.5px] border-border text-ink2 text-[14px] font-medium py-[10px] cursor-pointer hover:border-ink3 transition-colors"
+                >
+                  {t('cancelButton')}
+                </button>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="flex-1 rounded-pill bg-red-500 text-white text-[14px] font-medium py-[10px] cursor-pointer disabled:opacity-60 hover:bg-red-600 transition-colors"
+                >
+                  {deleting ? t('deleting') : t('deleteButton')}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={handleDeleteFirstTap}
+              className="w-full rounded-pill border-[1.5px] border-red-200 text-red-500 text-[15px] font-medium py-[13px] cursor-pointer hover:bg-red-50 transition-colors"
+            >
+              {t('deleteButton')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -1,0 +1,542 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import OrangeHeader from '../components/OrangeHeader'
+import Wave from '../components/Wave'
+import FAB from '../components/FAB'
+import { api } from '../services/api'
+import { useLanguage } from '../context/LanguageContext'
+
+// ── Date helper ───────────────────────────────────────────────────────────────
+function todayISO() {
+  const d = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+// ── Skeleton primitive ────────────────────────────────────────────────────────
+function Skeleton({ className = '' }) {
+  return (
+    <div
+      className={`animate-pulse rounded-[10px] bg-sand ${className}`}
+      aria-hidden="true"
+    />
+  )
+}
+
+// ── Category config ───────────────────────────────────────────────────────────
+const CATEGORIES = [
+  { key: 'gym', labelKey: 'nutritionCategoryGym' },
+  { key: 'weight-loss', labelKey: 'nutritionCategoryWeightLoss' },
+  { key: 'diabetes', labelKey: 'nutritionCategoryDiabetes' },
+  { key: 'kidney', labelKey: 'nutritionCategoryKidney' },
+  { key: 'pregnancy', labelKey: 'nutritionCategoryPregnancy' },
+  { key: 'custom', labelKey: 'nutritionCategoryCustom' },
+]
+
+const MEDICAL_DISCLAIMER_CATEGORIES = new Set(['diabetes', 'kidney', 'pregnancy'])
+
+// Nutrients to show per category, with translation key and unit
+const CATEGORY_NUTRIENTS = {
+  gym: [
+    { key: 'calories', labelKey: 'nutritionCalories', unit: 'kcal' },
+    { key: 'protein', labelKey: 'nutritionProtein', unit: 'g' },
+    { key: 'carbs', labelKey: 'nutritionCarbs', unit: 'g' },
+    { key: 'fat', labelKey: 'nutritionFat', unit: 'g' },
+  ],
+  'weight-loss': [
+    { key: 'calories', labelKey: 'nutritionCalories', unit: 'kcal' },
+    { key: 'fat', labelKey: 'nutritionFat', unit: 'g' },
+    { key: 'sugar', labelKey: 'nutritionSugar', unit: 'g' },
+    { key: 'fiber', labelKey: 'nutritionFiber', unit: 'g' },
+  ],
+  diabetes: [
+    { key: 'carbs', labelKey: 'nutritionCarbs', unit: 'g' },
+    { key: 'sugar', labelKey: 'nutritionSugar', unit: 'g' },
+    { key: 'fiber', labelKey: 'nutritionFiber', unit: 'g' },
+  ],
+  kidney: [
+    { key: 'sodium', labelKey: 'nutritionSodium', unit: 'mg' },
+    { key: 'protein', labelKey: 'nutritionProtein', unit: 'g' },
+  ],
+  pregnancy: [
+    { key: 'calories', labelKey: 'nutritionCalories', unit: 'kcal' },
+    { key: 'protein', labelKey: 'nutritionProtein', unit: 'g' },
+    { key: 'folate', labelKey: 'nutritionFolate', unit: 'mcg' },
+    { key: 'iron', labelKey: 'nutritionIron', unit: 'mg' },
+  ],
+  custom: [
+    { key: 'calories', labelKey: 'nutritionCalories', unit: 'kcal' },
+    { key: 'protein', labelKey: 'nutritionProtein', unit: 'g' },
+    { key: 'carbs', labelKey: 'nutritionCarbs', unit: 'g' },
+    { key: 'fat', labelKey: 'nutritionFat', unit: 'g' },
+  ],
+}
+
+const MEAL_ORDER = ['breakfast', 'lunch', 'dinner', 'snack']
+const MEAL_LABEL_KEYS = {
+  breakfast: 'nutritionMealBreakfast',
+  lunch: 'nutritionMealLunch',
+  dinner: 'nutritionMealDinner',
+  snack: 'nutritionMealSnack',
+}
+
+// ── Nutrient progress bar ─────────────────────────────────────────────────────
+function NutrientBar({ label, actual, target, unit }) {
+  const pct = target > 0 ? Math.min((actual / target) * 100, 100) : 0
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-[5px]">
+        <span className="text-[12px] font-medium text-ink2">{label}</span>
+        <span className="text-[12px] text-ink3">
+          {actual ?? 0} / {target ?? '—'} {unit}
+        </span>
+      </div>
+      <div className="h-[6px] rounded-full bg-sand overflow-hidden">
+        <div
+          className="h-full rounded-full bg-orange transition-all duration-300"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={actual ?? 0}
+          aria-valuemin={0}
+          aria-valuemax={target ?? 100}
+          aria-label={label}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ── Daily summary card ────────────────────────────────────────────────────────
+function SummaryCard({ category, loading, summary, t }) {
+  const nutrients = CATEGORY_NUTRIENTS[category] ?? CATEGORY_NUTRIENTS.custom
+
+  if (loading) {
+    return (
+      <div className="mx-5 mb-5 rounded-[14px] border border-border bg-white px-5 py-4 flex flex-col gap-3">
+        <Skeleton className="h-[12px] w-1/3" />
+        {nutrients.map((n) => (
+          <div key={n.key} className="flex flex-col gap-[5px]">
+            <div className="flex justify-between">
+              <Skeleton className="h-[12px] w-[60px]" />
+              <Skeleton className="h-[12px] w-[80px]" />
+            </div>
+            <Skeleton className="h-[6px] w-full rounded-full" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-5 mb-5 rounded-[14px] border border-border bg-white px-5 py-4 flex flex-col gap-[14px]">
+      <p className="text-[13px] font-semibold text-ink1">Today</p>
+      {nutrients.map((n) => (
+        <NutrientBar
+          key={n.key}
+          label={t(n.labelKey) !== n.labelKey ? t(n.labelKey) : n.key}
+          actual={summary?.[n.key] ?? 0}
+          target={summary?.targets?.[n.key] ?? 0}
+          unit={n.unit}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ── Parsed food item row ──────────────────────────────────────────────────────
+function ParsedFoodRow({ food, checked, onToggle }) {
+  const id = `food-${food.name}-${Math.random().toString(36).slice(2)}`
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-start gap-3 py-[10px] border-b border-border last:border-0 cursor-pointer"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={() => onToggle(food.name)}
+        className="mt-[2px] w-4 h-4 accent-orange cursor-pointer shrink-0"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] font-medium text-ink1 leading-snug">{food.name}</p>
+        <p className="text-[11px] text-ink3 mt-[2px]">
+          {[
+            food.calories != null && `${food.calories} kcal`,
+            food.protein != null && `${food.protein}g protein`,
+            food.carbs != null && `${food.carbs}g carbs`,
+            food.fat != null && `${food.fat}g fat`,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        </p>
+      </div>
+    </label>
+  )
+}
+
+// ── Meal group card ───────────────────────────────────────────────────────────
+function MealGroup({ mealType, entries, t, onEntryClick }) {
+  const label = t(MEAL_LABEL_KEYS[mealType] ?? mealType)
+  const totalCal = entries.reduce((sum, e) => {
+    const c = e.foods?.reduce((s, f) => s + (f.calories ?? 0), 0) ?? e.calories ?? 0
+    return sum + c
+  }, 0)
+
+  return (
+    <div className="rounded-[14px] border border-border bg-white overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-[10px] border-b border-border bg-sand/40">
+        <p className="text-[13px] font-semibold text-ink1">{label}</p>
+        <p className="text-[12px] text-ink3">{totalCal} kcal</p>
+      </div>
+      {entries.map((entry) => {
+        const names = entry.foods?.map((f) => f.name).join(', ') ?? entry.rawText ?? '—'
+        const cal =
+          entry.foods?.reduce((s, f) => s + (f.calories ?? 0), 0) ?? entry.calories ?? 0
+        return (
+          <button
+            key={entry._id}
+            type="button"
+            onClick={() => onEntryClick(entry._id)}
+            className="w-full text-left flex items-center justify-between px-4 py-[11px] border-b border-border last:border-0 hover:bg-sand/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange"
+          >
+            <p className="text-[13px] text-ink1 truncate pr-4">{names}</p>
+            <p className="text-[12px] text-ink3 shrink-0">{cal} kcal</p>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Main screen ───────────────────────────────────────────────────────────────
+export default function NutritionTracker() {
+  const navigate = useNavigate()
+  const { t } = useLanguage()
+  const today = todayISO()
+
+  // ── Category state ────────────────────────────────────────────────────────
+  const [category, setCategory] = useState('gym')
+  const [categoryLoading, setCategoryLoading] = useState(true)
+
+  // ── Summary state ─────────────────────────────────────────────────────────
+  const [summary, setSummary] = useState(null)
+  const [summaryLoading, setSummaryLoading] = useState(true)
+
+  // ── Food log state ────────────────────────────────────────────────────────
+  const [entries, setEntries] = useState([])
+  const [entriesLoading, setEntriesLoading] = useState(true)
+  const [entriesError, setEntriesError] = useState(null)
+
+  // ── AI input state ────────────────────────────────────────────────────────
+  const [aiText, setAiText] = useState('')
+  const [aiParsing, setAiParsing] = useState(false)
+  const [parsedFoods, setParsedFoods] = useState([])
+  const [checkedFoods, setCheckedFoods] = useState(new Set())
+  const [aiError, setAiError] = useState(null)
+  const [addingToLog, setAddingToLog] = useState(false)
+
+  // ── Fetch category on mount ───────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false
+    async function fetchCategory() {
+      try {
+        const res = await api.nutrition.getCategory()
+        if (!cancelled) {
+          const cat = res?.data?.category ?? res?.category ?? 'gym'
+          setCategory(cat)
+        }
+      } catch {
+        // fallback to 'gym'
+      } finally {
+        if (!cancelled) setCategoryLoading(false)
+      }
+    }
+    fetchCategory()
+    return () => { cancelled = true }
+  }, [])
+
+  // ── Fetch summary ─────────────────────────────────────────────────────────
+  const fetchSummary = useCallback(async () => {
+    setSummaryLoading(true)
+    try {
+      const res = await api.nutrition.summary(today)
+      setSummary(res?.data ?? res ?? null)
+    } catch {
+      setSummary(null)
+    } finally {
+      setSummaryLoading(false)
+    }
+  }, [today])
+
+  // ── Fetch today's log ─────────────────────────────────────────────────────
+  const fetchEntries = useCallback(async () => {
+    setEntriesLoading(true)
+    setEntriesError(null)
+    try {
+      const res = await api.nutrition.list(today)
+      const data = res?.data ?? res ?? []
+      setEntries(Array.isArray(data) ? data : [])
+    } catch (err) {
+      setEntriesError(err?.message ?? 'Failed to load entries')
+      setEntries([])
+    } finally {
+      setEntriesLoading(false)
+    }
+  }, [today])
+
+  useEffect(() => {
+    fetchSummary()
+    fetchEntries()
+  }, [fetchSummary, fetchEntries])
+
+  // ── Category selection handler ────────────────────────────────────────────
+  async function handleSelectCategory(cat) {
+    setCategory(cat)
+    try {
+      await api.nutrition.setCategory(cat)
+    } catch {
+      // non-fatal — UI already updated optimistically
+    }
+  }
+
+  // ── AI parse handler ──────────────────────────────────────────────────────
+  async function handleAiParse() {
+    if (!aiText.trim()) return
+    setAiParsing(true)
+    setAiError(null)
+    setParsedFoods([])
+    setCheckedFoods(new Set())
+    try {
+      const res = await api.nutrition.aiParse(aiText.trim(), category)
+      const foods = res?.data?.foods ?? res?.foods ?? []
+      setParsedFoods(Array.isArray(foods) ? foods : [])
+      setCheckedFoods(new Set((Array.isArray(foods) ? foods : []).map((f) => f.name)))
+    } catch (err) {
+      setAiError(err?.message ?? 'Failed to parse — please try again')
+    } finally {
+      setAiParsing(false)
+    }
+  }
+
+  // ── Toggle food checkbox ──────────────────────────────────────────────────
+  function toggleFood(name) {
+    setCheckedFoods((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) {
+        next.delete(name)
+      } else {
+        next.add(name)
+      }
+      return next
+    })
+  }
+
+  // ── Add to log ────────────────────────────────────────────────────────────
+  async function handleAddToLog() {
+    const selected = parsedFoods.filter((f) => checkedFoods.has(f.name))
+    if (selected.length === 0) return
+    setAddingToLog(true)
+    try {
+      await api.nutrition.create({
+        date: today,
+        mealType: 'snack',
+        foods: selected,
+        rawText: aiText.trim(),
+      })
+      setAiText('')
+      setParsedFoods([])
+      setCheckedFoods(new Set())
+      await Promise.all([fetchEntries(), fetchSummary()])
+    } catch (err) {
+      setAiError(err?.message ?? 'Failed to add to log — please try again')
+    } finally {
+      setAddingToLog(false)
+    }
+  }
+
+  // ── Compute calorie subtitle ──────────────────────────────────────────────
+  const calSub = (() => {
+    if (summaryLoading || categoryLoading) return t('nutritionSub')
+    const actual = summary?.calories ?? 0
+    const target = summary?.targets?.calories ?? 0
+    if (!target) return t('nutritionSub')
+    return `${actual.toLocaleString()} / ${target.toLocaleString()} kcal`
+  })()
+
+  // ── Group entries by mealType ─────────────────────────────────────────────
+  const mealGroups = MEAL_ORDER.reduce((acc, mt) => {
+    const group = entries.filter(
+      (e) => (e.mealType ?? '').toLowerCase() === mt
+    )
+    if (group.length > 0) acc[mt] = group
+    return acc
+  }, {})
+
+  const showDisclaimer = MEDICAL_DISCLAIMER_CATEGORIES.has(category)
+
+  return (
+    <div className="min-h-screen bg-page">
+      {/* ── Orange header ── */}
+      <OrangeHeader
+        title={t('nutritionTitle')}
+        subtitle={calSub}
+      />
+
+      {/* ── Wave separator ── */}
+      <div className="-mt-[40px]">
+        <Wave />
+      </div>
+
+      {/* ── Category selector ── */}
+      <div className="px-5 mb-5">
+        <div
+          className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide"
+          role="group"
+          aria-label="Nutrition category"
+          style={{ WebkitOverflowScrolling: 'touch' }}
+        >
+          {CATEGORIES.map(({ key, labelKey }) => {
+            const active = category === key
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => handleSelectCategory(key)}
+                aria-pressed={active}
+                disabled={categoryLoading}
+                className={[
+                  'shrink-0 px-[14px] py-[7px] rounded-pill text-[12px] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange',
+                  active
+                    ? 'bg-orange text-white'
+                    : 'bg-sand text-ink2 hover:bg-orange/10',
+                  categoryLoading ? 'opacity-60 cursor-wait' : 'cursor-pointer',
+                ].join(' ')}
+              >
+                {t(labelKey)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* ── Medical disclaimer ── */}
+      {showDisclaimer && (
+        <div
+          className="mx-5 mb-5 px-4 py-3 rounded-[12px] bg-[#FDE8DE]"
+          role="note"
+          aria-label="Medical disclaimer"
+        >
+          <p className="text-[12px] text-ink2">{t('nutritionDisclaimer')}</p>
+        </div>
+      )}
+
+      {/* ── Daily summary card ── */}
+      <SummaryCard
+        category={category}
+        loading={summaryLoading}
+        summary={summary}
+        t={t}
+      />
+
+      {/* ── AI input section ── */}
+      <div className="mx-5 mb-5 rounded-[14px] border border-border bg-white px-5 py-5">
+        <p className="text-[14px] font-semibold text-ink1 mb-3">AI Food Analyser</p>
+
+        <textarea
+          value={aiText}
+          onChange={(e) => setAiText(e.target.value)}
+          placeholder={t('nutritionAiPlaceholder')}
+          rows={3}
+          disabled={aiParsing}
+          className="w-full border border-border rounded-[10px] px-3 py-[10px] text-[14px] text-ink1 placeholder:text-ink3 resize-none focus:outline-none focus:ring-2 focus:ring-orange/50 bg-white disabled:opacity-60"
+        />
+
+        {/* Parse button */}
+        <button
+          type="button"
+          onClick={handleAiParse}
+          disabled={aiParsing || !aiText.trim()}
+          className="mt-3 w-full rounded-[10px] bg-orange text-white text-[13px] font-semibold py-[10px] hover:bg-orange-dk transition-colors disabled:opacity-60 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-orange"
+        >
+          {aiParsing ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="w-[14px] h-[14px] border-2 border-white/40 border-t-white rounded-full animate-spin" />
+              {t('nutritionAiParsing')}
+            </span>
+          ) : (
+            'Analyse'
+          )}
+        </button>
+
+        {/* AI error */}
+        {aiError && (
+          <p className="mt-2 text-[12px] text-[#E11D48]" role="alert">
+            {aiError}
+          </p>
+        )}
+
+        {/* Parsed foods */}
+        {parsedFoods.length > 0 && (
+          <div className="mt-4">
+            <p className="text-[12px] font-medium text-ink2 mb-1">
+              {t('nutritionAiParsed').replace('{n}', parsedFoods.length)}
+            </p>
+            <div className="border border-border rounded-[10px] overflow-hidden">
+              {parsedFoods.map((food) => (
+                <ParsedFoodRow
+                  key={food.name}
+                  food={food}
+                  checked={checkedFoods.has(food.name)}
+                  onToggle={toggleFood}
+                />
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={handleAddToLog}
+              disabled={addingToLog || checkedFoods.size === 0}
+              className="mt-3 w-full rounded-[10px] border border-orange text-orange text-[13px] font-semibold py-[10px] hover:bg-orange/5 transition-colors disabled:opacity-60 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-orange"
+            >
+              {addingToLog ? 'Adding…' : t('nutritionConfirm')}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Today's food log ── */}
+      <div className="px-5 pb-[100px]">
+        <p className="text-[14px] font-semibold text-ink1 mb-3">Today's log</p>
+
+        {entriesLoading ? (
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-[90px]" />
+            <Skeleton className="h-[90px]" />
+          </div>
+        ) : entriesError ? (
+          <p className="text-[13px] text-ink3 text-center py-6">{entriesError}</p>
+        ) : Object.keys(mealGroups).length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <p className="text-[15px] text-ink2 font-medium mb-1">{t('nutritionEmpty')}</p>
+            <p className="text-[13px] text-ink3">{t('nutritionEmptySub')}</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {MEAL_ORDER.filter((mt) => mealGroups[mt]).map((mt) => (
+              <MealGroup
+                key={mt}
+                mealType={mt}
+                entries={mealGroups[mt]}
+                t={t}
+                onEntryClick={(id) => navigate(`/nutrition/${id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── FAB — manual add ── */}
+      <FAB onClick={() => navigate('/nutrition/add')} />
+    </div>
+  )
+}


### PR DESCRIPTION
Rebased version of #71 on top of current main.

## Changes
- `src/App.jsx` — adds imports + 3 routes: `/nutrition`, `/nutrition/add`, `/nutrition/:id`
- `src/components/WebShell.jsx` — adds Nutrition nav entry after Cabinet
- `src/screens/NutritionTracker.jsx` — main screen (542 lines)
- `src/screens/NutritionAdd.jsx` — manual entry + AI parse (406 lines)
- `src/screens/NutritionDetail.jsx` — view/edit/delete (475 lines)

Closes #63. Supersedes #71 (conflict), #68, #69, #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)