### PR TITLE
fix: remove broken img rendering from AI product search results

### DIFF
--- a/src/screens/CabinetAdd.jsx
+++ b/src/screens/CabinetAdd.jsx
@@ -257,18 +257,7 @@ export default function CabinetAdd() {
                             : 'border-border bg-page hover:border-ink3/30'
                         }`}
                       >
-                        {r.imageUrl ? (
-                          <img
-                            src={r.imageUrl}
-                            alt={r.name || ''}
-                            className="w-10 h-10 object-contain rounded-[6px]"
-                            onError={(e) => { e.target.style.display = 'none'; e.target.nextSibling.style.display = 'flex' }}
-                          />
-                        ) : null}
-                        <div
-                          className="w-10 h-10 rounded-[6px] bg-sand items-center justify-center text-[16px] text-ink3/40"
-                          style={{ display: r.imageUrl ? 'none' : 'flex' }}
-                        >
+                        <div className="w-10 h-10 rounded-[6px] bg-sand flex items-center justify-center text-[16px] text-ink3/40">
                           {(r.name || '?').charAt(0).toUpperCase()}
                         </div>
                         <span className="text-[11px] text-ink1 font-medium text-center leading-tight line-clamp-2">
@@ -285,18 +274,7 @@ export default function CabinetAdd() {
                     return (
                       <div className="rounded-[12px] border border-border overflow-hidden bg-white">
                         <div className="relative w-full aspect-[2/1] bg-sand flex items-center justify-center">
-                          {p.imageUrl ? (
-                            <img
-                              src={p.imageUrl}
-                              alt={p.name || ''}
-                              className="w-full h-full object-contain p-5"
-                              onError={(e) => { e.target.style.display = 'none'; e.target.nextSibling.style.display = 'flex' }}
-                            />
-                          ) : null}
-                          <div
-                            className="w-full h-full items-center justify-center text-[40px] font-semibold"
-                            style={{ display: p.imageUrl ? 'none' : 'flex', color: '#E07B4A22' }}
-                          >
+                          <div className="w-full h-full flex items-center justify-center text-[40px] font-semibold" style={{ color: '#E07B4A22' }}>
                             {(p.name || '?').charAt(0).toUpperCase()}
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- Remove all `<img>` elements from AI search result cards (thumbnail + detail hero)
- Always show the letter placeholder — clean, no failed network requests
- Pairs with recallth-backend#122 which strips `imageUrl` from the backend response

Closes #77

## Why
QA confirmed (after backend fix was merged) that broken `<img>` elements were still firing 6 ERR_BLOCKED_BY_ORB requests per search. The AI returns product page URLs, not image URLs. There's no reliable way to get real product images from the AI — letter placeholders are the correct UX.

## Test plan
- [ ] Search for a product on `/cabinet/add` AI search
- [ ] All 3 result cards show letter placeholders, no broken image icons
- [ ] Zero failed image requests in DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)