### PR TITLE
feat: restore product image display in AI search results

### DIFF
--- a/src/screens/CabinetAdd.jsx
+++ b/src/screens/CabinetAdd.jsx
@@ -257,7 +257,18 @@ export default function CabinetAdd() {
                             : 'border-border bg-page hover:border-ink3/30'
                         }`}
                       >
-                        <div className="w-10 h-10 rounded-[6px] bg-sand flex items-center justify-center text-[16px] text-ink3/40">
+                        {r.imageUrl ? (
+                          <img
+                            src={r.imageUrl}
+                            alt={r.name || ''}
+                            className="w-10 h-10 object-contain rounded-[6px]"
+                            onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling.style.display = 'flex' }}
+                          />
+                        ) : null}
+                        <div
+                          className="w-10 h-10 rounded-[6px] bg-sand items-center justify-center text-[16px] text-ink3/40"
+                          style={{ display: r.imageUrl ? 'none' : 'flex' }}
+                        >
                           {(r.name || '?').charAt(0).toUpperCase()}
                         </div>
                         <span className="text-[11px] text-ink1 font-medium text-center leading-tight line-clamp-2">
@@ -274,7 +285,18 @@ export default function CabinetAdd() {
                     return (
                       <div className="rounded-[12px] border border-border overflow-hidden bg-white">
                         <div className="relative w-full aspect-[2/1] bg-sand flex items-center justify-center">
-                          <div className="w-full h-full flex items-center justify-center text-[40px] font-semibold" style={{ color: '#E07B4A22' }}>
+                          {p.imageUrl ? (
+                            <img
+                              src={p.imageUrl}
+                              alt={p.name || ''}
+                              className="w-full h-full object-contain p-5"
+                              onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling.style.display = 'flex' }}
+                            />
+                          ) : null}
+                          <div
+                            className="w-full h-full items-center justify-center text-[40px] font-semibold"
+                            style={{ display: p.imageUrl ? 'none' : 'flex', color: '#E07B4A22' }}
+                          >
                             {(p.name || '?').charAt(0).toUpperCase()}
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- Restore `<img>` rendering in thumbnail cards and the detail hero for AI search results
- Uses `nextElementSibling` (not `nextSibling`) in `onError` — correctly skips text nodes to find the fallback `<div>`
- Products with a real `imageUrl` from Open Food Facts show the product image
- Products without an image show the letter placeholder cleanly

Closes #79
Pairs with recallth-backend#124

## Test plan
- [ ] Search a common supplement — product image appears in card + detail hero
- [ ] Search an obscure product — letter placeholder shows, no broken image icons
- [ ] No ERR_BLOCKED_BY_ORB or 404 image errors in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)