### PR TITLE
fix: add bottom padding when batch delete bar visible (#133)

### DIFF
--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -1538,7 +1538,7 @@ export default function NutritionTracker() {
             </div>
 
             {/* Today's food log */}
-            <div className="pb-[100px] md:pb-8">
+            <div className={`pb-[100px] ${selectMode && selectedIds.size > 0 ? 'md:pb-20' : 'md:pb-8'}`}>
               {/* Date + metric row */}
               <div className="flex items-center justify-between mb-3 md:mb-4">
                 <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Floating "Delete (N)" bar was overlapping the last list item on desktop
- When delete bar is active, applies `md:pb-20` (80px) instead of `md:pb-8` (32px)
- Mobile was already fine (`pb-[100px]`)

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)