### PR TITLE
fix: clarify macro labels (#99) + desktop profile header (#105)

### DIFF
--- a/src/screens/NutritionAdd.jsx
+++ b/src/screens/NutritionAdd.jsx
@@ -42,6 +42,7 @@ const selectClass =
 
 // Shared result card used by Search and Photo tabs
 function NutritionResultCard({ item, selected, onSelect }) {
+  const { t } = useLanguage()
   const name = item.name ?? item.product_name ?? ''
   const brand = item.brand ?? item.brands ?? ''
   const calories = item.nutrients?.calories ?? item.calories ?? item.nutriments?.energy_value ?? undefined
@@ -76,13 +77,13 @@ function NutritionResultCard({ item, selected, onSelect }) {
       {(protein !== undefined || carbs !== undefined || fat !== undefined) && (
         <div className="flex gap-2 mt-1.5 flex-wrap">
           {protein !== undefined && (
-            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">P {protein}g</span>
+            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">{t('nutritionProtein')} {protein}g</span>
           )}
           {carbs !== undefined && (
-            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">C {carbs}g</span>
+            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">{t('nutritionCarbs')} {carbs}g</span>
           )}
           {fat !== undefined && (
-            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">F {fat}g</span>
+            <span className="text-[11px] text-ink3 bg-sand rounded-pill px-2 py-0.5">{t('nutritionFat')} {fat}g</span>
           )}
         </div>
       )}
@@ -640,13 +641,13 @@ export default function NutritionAdd() {
                               {(item.nutrients || item.protein !== undefined) && (
                                 <div className="flex gap-3 mt-1">
                                   {(item.nutrients?.protein ?? item.protein) !== undefined && (
-                                    <span className="text-[11px] text-ink3">P {item.nutrients?.protein ?? item.protein}g</span>
+                                    <span className="text-[11px] text-ink3">{t('nutritionProtein')} {item.nutrients?.protein ?? item.protein}g</span>
                                   )}
                                   {(item.nutrients?.carbs ?? item.carbs) !== undefined && (
-                                    <span className="text-[11px] text-ink3">C {item.nutrients?.carbs ?? item.carbs}g</span>
+                                    <span className="text-[11px] text-ink3">{t('nutritionCarbs')} {item.nutrients?.carbs ?? item.carbs}g</span>
                                   )}
                                   {(item.nutrients?.fat ?? item.fat) !== undefined && (
-                                    <span className="text-[11px] text-ink3">F {item.nutrients?.fat ?? item.fat}g</span>
+                                    <span className="text-[11px] text-ink3">{t('nutritionFat')} {item.nutrients?.fat ?? item.fat}g</span>
                                   )}
                                 </div>
                               )}

--- a/src/screens/Profile.jsx
+++ b/src/screens/Profile.jsx
@@ -794,6 +794,25 @@ export default function Profile() {
         <Wave />
       </div>
 
+      {/* Desktop-only header */}
+      <div className="hidden md:flex items-center gap-4 px-5 pt-6 pb-4">
+        <div className="w-[64px] h-[64px] rounded-full flex items-center justify-center shrink-0 bg-orange/15 text-orange text-[22px] font-medium">
+          {avatarLetter}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-[20px] font-medium text-ink1 leading-tight truncate">{displayName}</h1>
+          {email && <p className="text-[13px] text-ink3 mt-0.5 truncate">{email}</p>}
+        </div>
+        <div className="flex items-center gap-5 shrink-0">
+          {stats.map((s) => (
+            <div key={s.label} className="flex flex-col items-center">
+              <span className="text-[18px] font-semibold text-ink1 leading-none">{s.value}</span>
+              <span className="text-[11px] text-ink3 mt-1">{s.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
       {/* Quick action pills */}
       <div className="flex gap-3 px-5 py-4">
         {quickActions.map(({ label, path }) => (


### PR DESCRIPTION
## Summary
- **#99** — Replace hardcoded `P/C/F` macro abbreviations in `NutritionAdd.jsx` food result cards with translated `nutritionProtein/Carbs/Fat` labels so zh-HK users see `蛋白質/碳水/脂肪`.
- **#105** — Add desktop-only profile header (avatar, name, email, stats) so the `md+` layout is no longer blank at the top now that `OrangeHeader` and `Wave` are mobile-only. Existing `md:mt-0` on the wave wrapper already neutralised the negative margin.
- **#114** — Verified stale: `@dnd-kit/core@^6.3.1` is already in `package.json`, and `@dnd-kit/sortable` is not imported anywhere. No changes needed; issue can be closed.

## Test plan
- [ ] Open `/nutrition/add` in zh-HK — Search / Photo / Describe result cards show `蛋白質 40g` instead of `P 40g`
- [ ] Open `/nutrition/add` in en — cards show `Protein 40g`
- [ ] Open `/profile` on desktop (md+) — avatar, name, email, and 3-stat row render at the top; quick action pills fully visible below
- [ ] Open `/profile` on mobile — unchanged (orange header + wave + pills as before)

Closes #99
Closes #105
Closes #114

https://claude.ai/code/session_014CtUDQjMZCqgiHyHN5eTQx