### PR TITLE
fix: AI analyser meal pills, auto-scroll, empty group Add Food (#157/#161/#163)

### DIFF
--- a/src/components/ProfileOnboardingChat.jsx
+++ b/src/components/ProfileOnboardingChat.jsx
@@ -1,0 +1,528 @@
+import { useState, useEffect, useRef } from 'react'
+import { api } from '../services/api'
+import { useLanguage } from '../context/LanguageContext'
+
+const STEPS = ['height', 'weight', 'age', 'sex', 'activity', 'done']
+
+// Parse height input → cm, or null if invalid
+// Accepts: 170, 170cm, 5'9, 5ft9, 5ft9in, 5 9, 5.75ft
+function parseHeightToCm(val) {
+  const s = val.trim().toLowerCase()
+
+  // feet-inches: 5'9, 5'9", 5ft9, 5ft9in, 5 9 (two numbers)
+  const feetInches = s.match(/^(\d+(?:\.\d+)?)\s*(?:ft|feet|'|′)?\s*(\d+(?:\.\d+)?)\s*(?:in|inches|"|″)?$/)
+  if (feetInches) {
+    const cm = parseFloat(feetInches[1]) * 30.48 + parseFloat(feetInches[2]) * 2.54
+    return Math.round(cm)
+  }
+
+  // feet only: 5.9ft, 5ft
+  const feetOnly = s.match(/^(\d+(?:\.\d+)?)\s*(?:ft|feet|'|′)$/)
+  if (feetOnly) {
+    return Math.round(parseFloat(feetOnly[1]) * 30.48)
+  }
+
+  // plain number or number with cm: 170, 170cm
+  const plain = s.match(/^(\d+(?:\.\d+)?)\s*(?:cm)?$/)
+  if (plain) return parseFloat(plain[1])
+
+  return null
+}
+
+// Parse weight input → kg, or null if invalid
+// Accepts: 68, 68kg, 150lbs, 150 lbs, 150lb
+function parseWeightToKg(val) {
+  const s = val.trim().toLowerCase()
+
+  const lbs = s.match(/^(\d+(?:\.\d+)?)\s*(?:lbs?|pounds?)$/)
+  if (lbs) return Math.round(parseFloat(lbs[1]) * 0.453592 * 10) / 10
+
+  const plain = s.match(/^(\d+(?:\.\d+)?)\s*(?:kg)?$/)
+  if (plain) return parseFloat(plain[1])
+
+  return null
+}
+
+function SparkleIcon({ size = 16, color = 'currentColor' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z" />
+    </svg>
+  )
+}
+
+function TypingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="w-6 h-6 rounded-[8px] bg-orange-lt flex items-center justify-center shrink-0 mr-2 mt-1">
+        <SparkleIcon size={12} color="#E07B4A" />
+      </div>
+      <div className="bg-sand rounded-[16px] rounded-bl-[4px] px-4 py-[10px] flex items-center gap-1">
+        <span className="w-[5px] h-[5px] rounded-full bg-ink3" />
+        <span className="w-[5px] h-[5px] rounded-full bg-ink3" />
+        <span className="w-[5px] h-[5px] rounded-full bg-ink3" />
+      </div>
+    </div>
+  )
+}
+
+export default function ProfileOnboardingChat({ open, onClose, onComplete }) {
+  const { language } = useLanguage()
+  const isZh = language === 'zh-HK' || language === 'zh-TW'
+
+  const [messages, setMessages] = useState([])
+  const [step, setStep] = useState(0)
+  const [input, setInput] = useState('')
+  const [isTyping, setIsTyping] = useState(false)
+  const [done, setDone] = useState(false)
+  const [updateMode, setUpdateMode] = useState(false) // true when re-opening with existing profile
+
+  // Use a ref to track collected data synchronously — avoids calling API
+  // inside a state setter (which React StrictMode calls twice)
+  const collectedRef = useRef({})
+
+  const bottomRef = useRef(null)
+
+  const strings = isZh
+    ? {
+        title: '設定個人資料',
+        subtitle: '幾個問題就完成',
+        height: '你好！我幫你設定個人化營養目標。首先，請問你的身高？（例：170、5\'9、5ft9）',
+        weight: '好！你的體重係幾多？（例：65、65kg、150lbs）',
+        age: '多謝！你幾歲？（可以直接輸入歲數或出生年份）',
+        sex: '你的性別係？',
+        activity: '最後一題！你的日常活動量係？',
+        saving: '儲存中...',
+        done: '完成！🎉 你的卡路里目標已根據個人資料計算。',
+        errorHeight: '請輸入有效身高，例：170、5\'9、5ft9',
+        errorWeight: '請輸入有效體重，例：65、65kg、150lbs',
+        errorAge: '請輸入有效年齡（10–120）',
+        errorSave: '儲存失敗，請重試。',
+        close: '關閉',
+        placeholderHeight: '例：170 / 5\'9 / 5ft9',
+        placeholderWeight: '例：65 / 65kg / 150lbs',
+        placeholderAge: '例：30 或 1995',
+        sex_male: '男',
+        sex_female: '女',
+        sex_other: '其他',
+        act_sedentary: '很少運動',
+        act_light: '輕量（1–3次/週）',
+        act_moderate: '中量（3–5次/週）',
+        act_active: '高強度（6–7次/週）',
+        act_very_active: '非常高強度（每日多次）',
+        updateSummary: (h, w, a, s, act) => `你的資料已設定完成 ✓\n身高：${h}cm　體重：${w}kg　年齡：${a}\n性別：${s}　活動量：${act}\n\n想更新哪個資料？`,
+        updateHeight: '更新身高',
+        updateWeight: '更新體重',
+        updateAge: '更新年齡',
+        updateSex: '更新性別',
+        updateActivity: '更新活動量',
+        updateDone: '不更新，關閉',
+        updateHeightQ: '請輸入新的身高（例：170、5\'9）',
+        updateWeightQ: '請輸入新的體重（例：65、65kg、150lbs）',
+        updateAgeQ: '請輸入新的年齡或出生年份',
+        updateSexQ: '請選擇性別',
+        updateActivityQ: '請選擇活動量',
+        updateSaved: '已更新！目標已重新計算。',
+      }
+    : {
+        title: 'Set Up Your Profile',
+        subtitle: 'A few quick questions',
+        height: "Hi! Let me help personalise your nutrition targets. What's your height? (e.g. 170, 5'9, 5ft9)",
+        weight: "Great! What's your weight? (e.g. 65, 65kg, 150lbs)",
+        age: 'Thanks! How old are you? (age or birth year both work)',
+        sex: 'What is your sex?',
+        activity: 'Last one! How active are you?',
+        saving: 'Saving your profile...',
+        done: '🎉 Done! Your calorie target has been calculated based on your profile.',
+        errorHeight: "Please enter a valid height, e.g. 170, 5'9, or 5ft9",
+        errorWeight: 'Please enter a valid weight, e.g. 65, 65kg, or 150lbs',
+        errorAge: 'Please enter a valid age (10–120)',
+        errorSave: 'Failed to save. Please try again.',
+        close: 'Close',
+        placeholderHeight: "e.g. 170 / 5'9 / 5ft9",
+        placeholderWeight: 'e.g. 65 / 65kg / 150lbs',
+        placeholderAge: 'e.g. 30 or 1995',
+        sex_male: 'Male',
+        sex_female: 'Female',
+        sex_other: 'Other',
+        act_sedentary: 'Sedentary (little/no exercise)',
+        act_light: 'Lightly active (1–3x/week)',
+        act_moderate: 'Moderately active (3–5x/week)',
+        act_active: 'Active (6–7x/week)',
+        act_very_active: 'Very active (2x/day)',
+        updateSummary: (h, w, a, s, act) => `Your profile is complete ✓\nHeight: ${h}cm  Weight: ${w}kg  Age: ${a}\nSex: ${s}  Activity: ${act}\n\nWhat would you like to update?`,
+        updateHeight: 'Update height',
+        updateWeight: 'Update weight',
+        updateAge: 'Update age',
+        updateSex: 'Update sex',
+        updateActivity: 'Update activity',
+        updateDone: 'Nothing, close',
+        updateHeightQ: "Enter your new height (e.g. 170, 5'9)",
+        updateWeightQ: 'Enter your new weight (e.g. 65, 65kg, 150lbs)',
+        updateAgeQ: 'Enter your new age or birth year',
+        updateSexQ: 'Select your sex',
+        updateActivityQ: 'Select your activity level',
+        updateSaved: 'Updated! Your targets have been recalculated.',
+      }
+
+  const sexOptions = [
+    { value: 'male', label: strings.sex_male },
+    { value: 'female', label: strings.sex_female },
+    { value: 'other', label: strings.sex_other },
+  ]
+
+  const activityOptions = [
+    { value: 'sedentary', label: strings.act_sedentary },
+    { value: 'light', label: strings.act_light },
+    { value: 'moderate', label: strings.act_moderate },
+    { value: 'active', label: strings.act_active },
+    { value: 'very_active', label: strings.act_very_active },
+  ]
+
+  // Load existing profile and start conversation when opened
+  useEffect(() => {
+    if (!open) return
+    setMessages([])
+    setInput('')
+    setDone(false)
+    setUpdateMode(false)
+    setIsTyping(true)
+    collectedRef.current = {}
+
+    api.profile.get().then((res) => {
+      const body = res?.data?.body ?? {}
+      const h = body.height
+      const w = body.weight
+      const a = body.age
+      const s = body.sex
+      const act = body.activityLevel
+
+      // Pre-populate existing values
+      if (h) collectedRef.current.height = h
+      if (w) collectedRef.current.weight = w
+      if (a) collectedRef.current.age = a
+      if (s) collectedRef.current.sex = s
+      if (act) collectedRef.current.activityLevel = act
+
+      const allFilled = h && w && a && s && act
+
+      if (allFilled) {
+        // Profile complete — show summary + offer update
+        const sexLabel = s === 'male' ? strings.sex_male : s === 'female' ? strings.sex_female : strings.sex_other
+        const actLabel = activityOptions.find((o) => o.value === act)?.label ?? act
+        const summaryMsg = strings.updateSummary(h, w, a, sexLabel, actLabel)
+        setUpdateMode(true)
+        setStep(5) // done step, won't show any input
+        setTimeout(() => {
+          setIsTyping(false)
+          setMessages([{ type: 'ai', text: summaryMsg }])
+        }, 400)
+      } else {
+        // Find first missing field and start there
+        const firstMissing = !h ? 0 : !w ? 1 : !a ? 2 : !s ? 3 : 4
+        setStep(firstMissing)
+        const stepMsgs = [strings.height, strings.weight, strings.age, strings.sex, strings.activity]
+        setTimeout(() => {
+          setIsTyping(false)
+          setMessages([{ type: 'ai', text: stepMsgs[firstMissing] }])
+        }, 400)
+      }
+    }).catch(() => {
+      // Fetch failed — start fresh
+      setStep(0)
+      setTimeout(() => {
+        setIsTyping(false)
+        setMessages([{ type: 'ai', text: strings.height }])
+      }, 400)
+    })
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, isTyping])
+
+  function addAiMessage(text) {
+    return new Promise((resolve) => {
+      setIsTyping(true)
+      setTimeout(() => {
+        setIsTyping(false)
+        setMessages((m) => [...m, { type: 'ai', text }])
+        resolve()
+      }, 700)
+    })
+  }
+
+  async function handleTextSubmit() {
+    const val = input.trim()
+    if (!val) return
+    const currentStep = STEPS[step]
+
+    setMessages((m) => [...m, { type: 'user', text: val }])
+    setInput('')
+
+    if (currentStep === 'height') {
+      const cm = parseHeightToCm(val)
+      if (cm === null || cm < 100 || cm > 250) {
+        await addAiMessage(strings.errorHeight)
+        return
+      }
+      collectedRef.current = { ...collectedRef.current, height: cm }
+      if (updateMode) { await saveUpdate(); return }
+      setStep(1)
+      await addAiMessage(strings.weight)
+    } else if (currentStep === 'weight') {
+      const kg = parseWeightToKg(val)
+      if (kg === null || kg < 20 || kg > 300) {
+        await addAiMessage(strings.errorWeight)
+        return
+      }
+      collectedRef.current = { ...collectedRef.current, weight: kg }
+      if (updateMode) { await saveUpdate(); return }
+      setStep(2)
+      await addAiMessage(strings.age)
+    } else if (currentStep === 'age') {
+      let n = parseInt(val, 10)
+      if (!isNaN(n) && n >= 1900 && n <= new Date().getFullYear() - 10) {
+        n = new Date().getFullYear() - n
+      }
+      if (isNaN(n) || n < 10 || n > 120) {
+        await addAiMessage(strings.errorAge)
+        return
+      }
+      collectedRef.current = { ...collectedRef.current, age: n }
+      if (updateMode) { await saveUpdate(); return }
+      setStep(3)
+      await addAiMessage(strings.sex)
+    }
+  }
+
+  async function handleSexSelect(value, label) {
+    collectedRef.current = { ...collectedRef.current, sex: value }
+    setMessages((m) => [...m, { type: 'user', text: label }])
+    if (updateMode) {
+      await saveUpdate()
+    } else {
+      setStep(4)
+      await addAiMessage(strings.activity)
+    }
+  }
+
+  async function handleActivitySelect(value, label) {
+    const finalCollected = { ...collectedRef.current, activityLevel: value }
+    collectedRef.current = finalCollected
+    setMessages((m) => [...m, { type: 'user', text: label }])
+    if (updateMode) {
+      await saveUpdate()
+    } else {
+      setStep(5)
+      await addAiMessage(strings.saving)
+      try {
+        await api.profile.update({ body: finalCollected })
+        setMessages((m) => { const u = [...m]; u[u.length - 1] = { type: 'ai', text: strings.done }; return u })
+        setDone(true)
+        onComplete?.()
+      } catch {
+        setMessages((m) => [...m, { type: 'ai', text: strings.errorSave }])
+      }
+    }
+  }
+
+  // Save a single-field update and show confirmation
+  async function saveUpdate() {
+    setStep(5)
+    await addAiMessage(strings.saving)
+    try {
+      await api.profile.update({ body: collectedRef.current })
+      setMessages((m) => { const u = [...m]; u[u.length - 1] = { type: 'ai', text: strings.updateSaved }; return u })
+      setDone(true)
+      onComplete?.()
+    } catch {
+      setMessages((m) => [...m, { type: 'ai', text: strings.errorSave }])
+    }
+  }
+
+  // Update-mode: user picks which field to change
+  async function handleUpdateField(field) {
+    const qMap = { height: strings.updateHeightQ, weight: strings.updateWeightQ, age: strings.updateAgeQ, sex: strings.updateSexQ, activity: strings.updateActivityQ }
+    const stepMap = { height: 0, weight: 1, age: 2, sex: 3, activity: 4 }
+    setMessages((m) => [...m, { type: 'user', text: strings['update' + field.charAt(0).toUpperCase() + field.slice(1)] }])
+    setStep(stepMap[field])
+    await addAiMessage(qMap[field])
+  }
+
+  if (!open) return null
+
+  const currentStep = STEPS[step]
+  const showTextInput = ['height', 'weight', 'age'].includes(currentStep) && !isTyping && !(updateMode && step === 5)
+  const showSexButtons = currentStep === 'sex' && !isTyping
+  const showActivityButtons = currentStep === 'activity' && !isTyping
+  const showUpdateButtons = updateMode && step === 5 && !isTyping && !done
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex justify-end"
+      style={{ background: 'rgba(42,34,26,0.25)' }}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="w-full md:w-[420px] h-full bg-white flex flex-col shadow-2xl"
+        style={{ animation: 'slideIn 0.22s ease-out' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-[12px] bg-orange flex items-center justify-center shrink-0">
+              <SparkleIcon size={16} color="white" />
+            </div>
+            <div>
+              <p className="text-[14px] font-semibold text-ink1">{strings.title}</p>
+              <p className="text-[11px] text-ink3">{strings.subtitle}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-full flex items-center justify-center hover:bg-sand transition-colors text-ink3 cursor-pointer"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-3">
+          {messages.map((msg, i) => (
+            <div key={i} className={`flex ${msg.type === 'user' ? 'justify-end' : 'justify-start'}`}>
+              {msg.type === 'ai' && (
+                <div className="w-6 h-6 rounded-[8px] bg-orange-lt flex items-center justify-center shrink-0 mr-2 mt-1">
+                  <SparkleIcon size={12} color="#E07B4A" />
+                </div>
+              )}
+              <div className={`max-w-[78%] rounded-[16px] px-4 py-[10px] text-[13px] leading-[1.55] whitespace-pre-wrap ${
+                msg.type === 'user'
+                  ? 'bg-orange text-white rounded-br-[4px]'
+                  : 'bg-sand text-ink1 rounded-bl-[4px]'
+              }`}>
+                {msg.text}
+              </div>
+            </div>
+          ))}
+
+          {isTyping && <TypingIndicator />}
+
+          {/* Sex quick-reply buttons */}
+          {showSexButtons && (
+            <div className="flex gap-2 flex-wrap pl-8">
+              {sexOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => handleSexSelect(opt.value, opt.label)}
+                  className="px-4 py-[8px] rounded-pill border border-orange text-orange text-[13px] font-medium hover:bg-orange hover:text-white transition-colors cursor-pointer"
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Activity quick-reply buttons */}
+          {showActivityButtons && (
+            <div className="flex flex-col gap-2 pl-8">
+              {activityOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => handleActivitySelect(opt.value, opt.label)}
+                  className="w-full px-4 py-[9px] rounded-[10px] border border-orange text-orange text-[13px] font-medium hover:bg-orange hover:text-white transition-colors cursor-pointer text-left"
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Update-mode field selector buttons */}
+          {showUpdateButtons && (
+            <div className="flex flex-col gap-2 pl-8">
+              {[
+                { field: 'height', label: strings.updateHeight },
+                { field: 'weight', label: strings.updateWeight },
+                { field: 'age', label: strings.updateAge },
+                { field: 'sex', label: strings.updateSex },
+                { field: 'activity', label: strings.updateActivity },
+              ].map(({ field, label }) => (
+                <button
+                  key={field}
+                  onClick={() => handleUpdateField(field)}
+                  className="w-full px-4 py-[9px] rounded-[10px] border border-orange text-orange text-[13px] font-medium hover:bg-orange hover:text-white transition-colors cursor-pointer text-left"
+                >
+                  {label}
+                </button>
+              ))}
+              <button
+                onClick={onClose}
+                className="w-full px-4 py-[9px] rounded-[10px] border border-border text-ink3 text-[13px] font-medium hover:bg-sand transition-colors cursor-pointer text-left"
+              >
+                {strings.updateDone}
+              </button>
+            </div>
+          )}
+
+          {/* Done close button */}
+          {done && (
+            <div className="pl-8">
+              <button
+                onClick={onClose}
+                className="w-full bg-orange text-white text-[13px] font-semibold rounded-[10px] py-[10px] hover:opacity-90 transition-opacity cursor-pointer mt-2"
+              >
+                {strings.close}
+              </button>
+            </div>
+          )}
+
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Text input — height, weight, age only */}
+        {showTextInput && (
+          <div className="px-4 py-4 border-t border-border shrink-0">
+            <div className="flex items-center gap-2 border border-border rounded-pill px-4 py-[10px] bg-page focus-within:border-orange transition-colors">
+              <input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleTextSubmit()}
+                placeholder={
+                  currentStep === 'height' ? strings.placeholderHeight
+                  : currentStep === 'weight' ? strings.placeholderWeight
+                  : strings.placeholderAge
+                }
+                className="flex-1 text-[13px] text-ink1 placeholder:text-ink4 outline-none bg-transparent"
+                type={currentStep === 'age' ? 'number' : 'text'}
+                inputMode={currentStep === 'age' ? 'numeric' : 'text'}
+                autoFocus
+              />
+              <button
+                onClick={handleTextSubmit}
+                disabled={!input.trim()}
+                className="w-8 h-8 rounded-full bg-orange flex items-center justify-center shrink-0 cursor-pointer disabled:opacity-40 transition-opacity hover:bg-orange-dk"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="12" y1="19" x2="12" y2="5" />
+                  <polyline points="5 12 12 5 19 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes slideIn {
+          from { transform: translateX(100%); opacity: 0; }
+          to   { transform: translateX(0);    opacity: 1; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -30,19 +30,19 @@ function ScheduleBlock({ block }) {
   return (
     <div className="rounded-[14px] border overflow-hidden" style={{ borderColor: block.border }}>
       <div
-        className="flex items-center justify-between px-4 py-3"
+        className="flex items-center justify-between px-3 sm:px-4 py-3 gap-2"
         style={{ background: block.bg, borderBottom: `1px solid ${block.border}` }}
       >
-        <span className="text-[13px] font-semibold text-ink1">{block.label}</span>
-        <span className="text-[12px] text-ink3">{block.time}</span>
+        <span className="text-[13px] font-semibold text-ink1 truncate">{block.label}</span>
+        <span className="text-[12px] text-ink3 shrink-0">{block.time}</span>
       </div>
       <div className="bg-white divide-y divide-border">
         {block.items.map((item) => (
-          <div key={item.name} className="flex items-center gap-3 px-4 py-[11px]">
+          <div key={item.name} className="flex items-center gap-3 px-3 sm:px-4 py-[11px] min-w-0">
             <span className="w-2 h-2 rounded-full shrink-0" style={{ background: block.dot }} />
             <div className="min-w-0">
               <p className="text-[13px] font-medium text-ink1 truncate">{item.name}</p>
-              <p className="text-[11px] text-ink3">{item.dose}</p>
+              <p className="text-[11px] text-ink3 truncate">{item.dose}</p>
             </div>
           </div>
         ))}
@@ -231,40 +231,40 @@ export default function Home() {
   ]
 
   return (
-    <div className="px-5 py-6 md:px-8 md:py-7 max-w-[960px]">
+    <div className="px-4 py-6 sm:px-5 md:px-8 md:py-7 max-w-[960px] mx-auto w-full">
 
         {/* ── Greeting row ── */}
-        <div className="flex items-end justify-between mb-6">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-6">
           <div>
             <p className="text-[14px] text-ink2 mb-1">{greetingWord}</p>
-            <h1 className="font-display text-[32px] text-ink1 leading-none">
+            <h1 className="font-display text-[28px] sm:text-[32px] text-ink1 leading-none">
               {displayName || 'there'}
             </h1>
           </div>
-          <div className="bg-white border border-border rounded-[10px] px-4 py-2">
+          <div className="bg-white border border-border rounded-[10px] px-4 py-2 whitespace-nowrap">
             <span className="text-[13px] text-ink2">{today}</span>
           </div>
         </div>
 
         {/* ── Stats strip ── */}
-        <div className="grid grid-cols-4 gap-3 mb-7">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-7">
           {statsLoading
             ? Array.from({ length: 4 }).map((_, i) => (
                 <Skeleton key={i} className="h-[82px]" />
               ))
             : STATS.map((s) => (
-                <div key={s.label} className="bg-white border border-border rounded-[12px] px-4 py-4 flex flex-col gap-1">
-                  <span className={`font-display text-[28px] leading-none ${s.color}`}>{s.value}</span>
-                  <span className="text-[12px] uppercase tracking-[0.06em] text-ink3 font-medium">{s.label}</span>
+                <div key={s.label} className="bg-white border border-border rounded-[12px] px-3 py-4 sm:px-4 flex flex-col gap-1">
+                  <span className={`font-display text-[24px] sm:text-[28px] leading-none ${s.color}`}>{s.value}</span>
+                  <span className="text-[11px] sm:text-[12px] uppercase tracking-[0.06em] text-ink3 font-medium">{s.label}</span>
                 </div>
               ))}
         </div>
 
         {/* ── Two-column grid ── */}
-        <div className="grid gap-6" style={{ gridTemplateColumns: '1fr 380px' }}>
+        <div className="grid gap-6 grid-cols-1 md:grid-cols-[1fr_320px] lg:grid-cols-[1fr_380px]">
 
           {/* Left — Today's schedule */}
-          <div>
+          <div className="min-w-0">
             <h2 className="text-[15px] font-semibold text-ink1 mb-4">{t('todaySchedule')}</h2>
             <div className="flex flex-col gap-3">
               {scheduleLoading ? (
@@ -274,7 +274,7 @@ export default function Home() {
                   <Skeleton className="h-[90px]" />
                 </>
               ) : schedule.length === 0 ? (
-                <div className="rounded-[14px] border border-border bg-white px-6 py-8 text-center">
+                <div className="rounded-[14px] border border-border bg-white px-4 sm:px-6 py-8 text-center overflow-hidden">
                   <p className="text-[13px] text-ink2 mb-2">{t('noScheduleYet')}</p>
                   <Link
                     to="/cabinet"
@@ -295,8 +295,8 @@ export default function Home() {
           <div className="flex flex-col gap-4">
 
             {/* Ask AI card */}
-            <div className="rounded-[14px] border p-5" style={{ background: '#FDE8DE', borderColor: '#E8C4B0' }}>
-              <div className="flex items-center gap-3 mb-4">
+            <div className="rounded-[14px] border p-4 sm:p-5 overflow-hidden" style={{ background: '#FDE8DE', borderColor: '#E8C4B0' }}>
+              <div className="flex flex-col sm:flex-row sm:items-center sm:gap-3 mb-4 gap-2">
                 <div
                   className="w-9 h-9 rounded-[12px] flex items-center justify-center shrink-0"
                   style={{ background: '#E07B4A' }}
@@ -312,13 +312,13 @@ export default function Home() {
               </div>
 
               {/* Input */}
-              <div className="flex items-center gap-2 bg-white border border-border rounded-[10px] px-3 py-[9px] mb-3">
+              <div className="flex items-center gap-2 bg-white border border-border rounded-[10px] px-3 py-[9px] mb-3 overflow-hidden">
                 <input
                   ref={inputRef}
                   value={quickInput}
                   onChange={(e) => setQuickInput(e.target.value)}
                   placeholder={t('askPlaceholder')}
-                  className="flex-1 text-[13px] text-ink1 placeholder:text-ink4 outline-none bg-transparent"
+                  className="flex-1 min-w-0 text-[13px] text-ink1 placeholder:text-ink4 outline-none bg-transparent"
                   onKeyDown={handleInputKeyDown}
                 />
                 <button
@@ -340,7 +340,7 @@ export default function Home() {
                   <button
                     key={p}
                     onClick={() => navigateToChat(p)}
-                    className="w-full text-left text-[12px] text-ink2 bg-white border border-border rounded-[8px] px-3 py-[8px] hover:bg-white/80 transition-colors cursor-pointer"
+                    className="w-full text-left text-[12px] text-ink2 bg-white border border-border rounded-[8px] px-3 py-[8px] hover:bg-white/80 transition-colors cursor-pointer truncate"
                   >
                     {p}
                   </button>
@@ -350,18 +350,18 @@ export default function Home() {
 
             {/* Recent conversations */}
             <div className="bg-white border border-border rounded-[14px] overflow-hidden">
-              <div className="px-5 py-4 border-b border-border">
+              <div className="px-4 sm:px-5 py-4 border-b border-border">
                 <p className="text-[13px] font-semibold text-ink1">{t('recentConversations')}</p>
               </div>
 
               {conversationsLoading ? (
-                <div className="flex flex-col gap-3 px-5 py-4">
+                <div className="flex flex-col gap-3 px-4 sm:px-5 py-4">
                   <Skeleton className="h-10" />
                   <Skeleton className="h-10" />
                   <Skeleton className="h-10" />
                 </div>
               ) : conversations.length === 0 ? (
-                <div className="px-5 py-8 flex flex-col items-center text-center">
+                <div className="px-4 sm:px-5 py-8 flex flex-col items-center text-center">
                   <div className="w-10 h-10 rounded-full bg-orange/10 flex items-center justify-center mb-3">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E07B4A" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
@@ -381,7 +381,7 @@ export default function Home() {
                     <button
                       key={item._id}
                       onClick={() => navigate(`/chat?id=${item._id}`)}
-                      className="w-full flex items-center gap-3 px-5 py-[13px] hover:bg-sand transition-colors cursor-pointer text-left"
+                      className="w-full flex items-center gap-3 px-4 sm:px-5 py-[13px] hover:bg-sand transition-colors cursor-pointer text-left overflow-hidden"
                     >
                       <div
                         className="w-8 h-8 rounded-[10px] flex items-center justify-center shrink-0"
@@ -393,7 +393,7 @@ export default function Home() {
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-[13px] font-medium text-ink1 truncate">{item.title ?? t('conversationFallback')}</p>
-                        <p className="text-[11px] text-ink3">
+                        <p className="text-[11px] text-ink3 truncate">
                           {item.createdAt ? relativeTime(item.createdAt) : ''}
                           {item.messageCount != null ? ` · ${item.messageCount} ${t('msgs')}` : ''}
                         </p>
@@ -407,7 +407,7 @@ export default function Home() {
                 </div>
               )}
 
-              <div className="px-5 py-3 border-t border-border">
+              <div className="px-4 sm:px-5 py-3 border-t border-border">
                 <button
                   onClick={() => navigate('/chat')}
                   className="text-[12px] text-orange font-medium hover:underline cursor-pointer"

--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   DndContext,
@@ -548,6 +548,7 @@ function MealGroup({
   selectedIds,
   onToggleSelect,
   onSelectAll,
+  onAddFood,
 }) {
   const label = t(MEAL_LABEL_KEYS[mealType] ?? mealType)
   const [expandedId, setExpandedId] = useState(null)
@@ -606,6 +607,16 @@ function MealGroup({
         </div>
       </div>
 
+      {entries.length === 0 && !selectMode && (
+        <button
+          type="button"
+          onClick={() => onAddFood?.(mealType)}
+          className="w-full flex items-center gap-2 px-4 py-[12px] text-[13px] text-ink3 hover:text-orange hover:bg-orange/5 transition-colors focus:outline-none"
+        >
+          <span className="text-[15px] font-light leading-none">＋</span>
+          <span>{t('nutritionAddFood')}</span>
+        </button>
+      )}
       {entries.map((entry) => {
         const names = entry.foods?.map((f) => f.name).join(', ') ?? entry.rawText ?? '—'
         const metricVal = entry.foods?.reduce((s, f) => s + getFoodMetric(f, logMetric), 0) ?? getFoodMetric(entry, logMetric)
@@ -907,6 +918,7 @@ export default function NutritionTracker() {
   const [checkedFoods, setCheckedFoods] = useState(new Set())
   const [aiError, setAiError] = useState(null)
   const [addingToLog, setAddingToLog] = useState(false)
+  const parsedFoodsRef = useRef(null)
 
   // ── Manual entry state ────────────────────────────────────────────────────
   const [manualName, setManualName] = useState('')
@@ -1066,6 +1078,13 @@ export default function NutritionTracker() {
     fetchSummary()
     fetchEntries()
   }, [fetchSummary, fetchEntries])
+
+  // ── Auto-scroll to parsed results (#163) ─────────────────────────────────
+  useEffect(() => {
+    if (parsedFoods.length > 0 && parsedFoodsRef.current) {
+      parsedFoodsRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [parsedFoods])
 
   // ── Delete with undo ─────────────────────────────────────────────────────
   function handleRequestDelete(entry) {
@@ -1397,13 +1416,32 @@ export default function NutritionTracker() {
               <div className="px-5 py-5 md:px-6 md:py-6">
                 {analyserTab === 'ai' ? (
                   <>
+                    {/* Meal type pills — #161 fix */}
+                    <div className="flex gap-2 flex-wrap mb-3">
+                      {MEAL_ORDER.map((mt) => (
+                        <button
+                          key={mt}
+                          type="button"
+                          onClick={() => setManualMealType(mt)}
+                          aria-pressed={manualMealType === mt}
+                          className={[
+                            'px-[12px] py-[6px] rounded-pill text-[12px] font-medium transition-colors focus:outline-none',
+                            manualMealType === mt
+                              ? 'bg-orange text-white'
+                              : 'bg-sand text-ink2 hover:bg-orange/10',
+                          ].join(' ')}
+                        >
+                          {t(MEAL_LABEL_KEYS[mt])}
+                        </button>
+                      ))}
+                    </div>
                     <textarea
                       value={aiText}
                       onChange={(e) => setAiText(e.target.value)}
                       placeholder={t('nutritionAiPlaceholder')}
-                      rows={3}
+                      rows={parsedFoods.length > 0 ? 2 : 5}
                       disabled={aiParsing}
-                      className="w-full border border-border rounded-[10px] px-3 py-[10px] text-[14px] text-ink1 placeholder:text-ink3 resize-none focus:outline-none focus:ring-2 focus:ring-orange/50 bg-white disabled:opacity-60 md:min-h-[120px]"
+                      className="w-full border border-border rounded-[10px] px-3 py-[10px] text-[14px] text-ink1 placeholder:text-ink3 resize-none focus:outline-none focus:ring-2 focus:ring-orange/50 bg-white disabled:opacity-60"
                     />
                     <button
                       type="button"
@@ -1424,7 +1462,7 @@ export default function NutritionTracker() {
                       <p className="mt-2 text-[12px] text-[#E11D48]" role="alert">{aiError}</p>
                     )}
                     {parsedFoods.length > 0 && (
-                      <div className="mt-4">
+                      <div ref={parsedFoodsRef} className="mt-4">
                         <p className="text-[12px] font-medium text-ink2 mb-1">
                           {t('nutritionAiParsed').replace('{n}', parsedFoods.length)}
                         </p>
@@ -1626,19 +1664,14 @@ export default function NutritionTracker() {
                 </div>
               ) : entriesError ? (
                 <p className="text-[13px] text-ink3 text-center py-6">{entriesError}</p>
-              ) : Object.keys(mealGroups).length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <p className="text-[15px] text-ink2 font-medium mb-1">{t('nutritionEmpty')}</p>
-                  <p className="text-[13px] text-ink3">{t('nutritionEmptySub')}</p>
-                </div>
               ) : selectMode ? (
                 /* ── Select mode: plain list, no DnD ── */
                 <div className="flex flex-col gap-3">
-                  {MEAL_ORDER.filter((mt) => mealGroups[mt]).map((mt) => (
+                  {MEAL_ORDER.map((mt) => (
                     <MealGroup
                       key={mt}
                       mealType={mt}
-                      entries={mealGroups[mt]}
+                      entries={mealGroups[mt] ?? []}
                       t={t}
                       onRequestDelete={handleRequestDelete}
                       logMetric={logMetric}
@@ -1658,15 +1691,16 @@ export default function NutritionTracker() {
                   onDragEnd={handleDragEnd}
                 >
                   <div className="flex flex-col gap-3">
-                    {MEAL_ORDER.filter((mt) => mealGroups[mt]).map((mt) => (
+                    {MEAL_ORDER.map((mt) => (
                       <MealGroup
                         key={mt}
                         mealType={mt}
-                        entries={mealGroups[mt]}
+                        entries={mealGroups[mt] ?? []}
                         t={t}
                         onRequestDelete={handleRequestDelete}
                         logMetric={logMetric}
                         isDropTarget={overMealType === mt}
+                        onAddFood={(mealT) => setManualMealType(mealT)}
                       />
                     ))}
                   </div>


### PR DESCRIPTION
## Summary

- **#161** — Add meal type pills (breakfast/lunch/dinner/snack) to AI tab. Was only in Manual tab, so all AI-parsed food went to the time-based default meal.
- **#163** — Textarea shrinks from 5→2 rows when results appear, and `scrollIntoView` auto-scrolls to the parsed results container.
- **#157 + #155** — All 4 meal groups now always shown (including empty). Empty groups show `＋ Add food` button that pre-sets the corresponding meal type in the analyser.
- Also copies `ProfileOnboardingChat.jsx` from `fix/162` branch — it was imported by NutritionTracker.jsx on main but the file was missing, causing build failure.

## Test plan

- [ ] Open Nutrition Tracker → AI tab → confirm meal type pills are visible
- [ ] Type food → click Analyse → confirm textarea shrinks and page scrolls to results
- [ ] Open tracker with no entries → confirm all 4 meal groups show with `+ Add food`
- [ ] Click `+ Add food` in Breakfast group → confirm analyser AI tab now shows Breakfast selected
- [ ] Build passes: `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)