### PR TITLE
fix: remove profile sidebar nav, user strip → /profile (#151)

### DIFF
--- a/src/components/WebShell.jsx
+++ b/src/components/WebShell.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { NavLink } from 'react-router-dom'
+import { NavLink, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useLanguage } from '../context/LanguageContext'
 import BottomNav from './BottomNav'
@@ -142,16 +142,6 @@ const NAV_KEYS = [
       </svg>
     ),
   },
-  {
-    to: '/profile',
-    key: 'profile',
-    icon: () => (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="8" r="4" />
-        <path d="M20 21a8 8 0 0 0-16 0" />
-      </svg>
-    ),
-  },
 ]
 
 export default function WebShell({ children }) {
@@ -195,8 +185,11 @@ export default function WebShell({ children }) {
           ))}
         </nav>
 
-        {/* User strip */}
-        <div className="px-4 py-4 border-t border-border flex items-center gap-3">
+        {/* User strip — clickable → /profile */}
+        <Link
+          to="/profile"
+          className="px-4 py-4 border-t border-border flex items-center gap-3 hover:bg-sand/50 transition-colors"
+        >
           <div className="w-9 h-9 rounded-full bg-orange flex items-center justify-center shrink-0">
             <span className="text-white text-[14px] font-semibold">{avatarLetter}</span>
           </div>
@@ -204,7 +197,7 @@ export default function WebShell({ children }) {
             <p className="text-[13px] font-semibold text-ink1 truncate">{displayName}</p>
             <p className="text-[11px] text-ink3">{t('freePlan')}</p>
           </div>
-        </div>
+        </Link>
       </aside>
 
       {/* ── Content area ── */}


### PR DESCRIPTION
## Summary
- Remove `/profile` nav link from desktop sidebar `NAV_KEYS` (was duplicate — profile accessible via user strip)
- Convert user strip from plain `<div>` to `<Link to="/profile">` with hover state

## Definition of Done
- [ ] Profile nav item gone from desktop sidebar
- [ ] Clicking user strip (avatar + name at bottom of sidebar) navigates to /profile
- [ ] Hover shows `bg-sand/50` highlight on user strip
- [ ] Build passes ✅

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)