### PR TITLE
fix: sessionTitle for Stack Builder / Doctor Prep history titles (#178)

### DIFF
--- a/src/screens/StackBuilder.jsx
+++ b/src/screens/StackBuilder.jsx
@@ -228,7 +228,7 @@ export default function StackBuilder() {
 
       try {
         const message = buildPrompt(goal.trim(), profile, cabinetItems)
-        const res = await chatService.send(message)
+        const res = await chatService.send(message, undefined, { sessionTitle: `Stack Builder: ${goal.trim().slice(0, 50)}` })
         const text = res?.data?.message?.content ?? ''
         const parsed = parseStackResponse(text)
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -63,7 +63,7 @@ export const api = {
     generate: (prompt) =>
       request('/chat', {
         method: 'POST',
-        body: JSON.stringify({ message: prompt }),
+        body: JSON.stringify({ message: prompt, sessionTitle: 'Doctor Prep' }),
       }),
   },
   settings: {

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -1,7 +1,7 @@
 import { request } from './api'
 
 export const chatService = {
-  send: (message, conversationId, { image, imageMimeType } = {}) => {
+  send: (message, conversationId, { image, imageMimeType, sessionTitle } = {}) => {
     const language = localStorage.getItem('recallth_language') || 'en'
     return request('/chat', {
       method: 'POST',
@@ -10,6 +10,7 @@ export const chatService = {
         language,
         ...(conversationId ? { conversationId } : {}),
         ...(image ? { image, imageMimeType } : {}),
+        ...(sessionTitle ? { sessionTitle } : {}),
       }),
     })
   },


### PR DESCRIPTION
## Summary
- `chatService.send()` now accepts `sessionTitle` in options
- `api.doctorPrep.generate()` passes `sessionTitle: 'Doctor Prep'`
- StackBuilder passes `sessionTitle: 'Stack Builder: <goal>'`
- Pairs with wkliwk/recallth-backend#162

## Test plan
- [ ] Stack Builder session → History shows "Stack Builder: <goal>" not system prompt
- [ ] Doctor Prep → History shows "Doctor Prep"
- [ ] Normal chat unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)