### PR TITLE
fix: redirect new users to /onboarding after signup (#177)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,9 +55,10 @@ function OnboardingRoute({ children }) {
 }
 
 function PublicRoute({ children }) {
-  const { isAuthenticated, isLoading } = useAuth()
+  const { isAuthenticated, isLoading, isNewUser } = useAuth()
   if (isLoading) return null
-  if (isAuthenticated) return <Navigate to="/home" replace />
+  // Don't redirect new users — Auth.handleSubmit handles navigation to /onboarding
+  if (isAuthenticated && !isNewUser) return <Navigate to="/home" replace />
   return children
 }
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -9,6 +9,7 @@ export function AuthProvider({ children }) {
   const [token, setToken] = useState(null)
   const [email, setEmail] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [isNewUser, setIsNewUser] = useState(false)
 
   useEffect(() => {
     const storedToken = localStorage.getItem(TOKEN_KEY)
@@ -18,22 +19,26 @@ export function AuthProvider({ children }) {
     setIsLoading(false)
   }, [])
 
-  const setAuth = useCallback((newToken, newEmail) => {
+  const setAuth = useCallback((newToken, newEmail, newUser = false) => {
     localStorage.setItem(TOKEN_KEY, newToken)
     localStorage.setItem(EMAIL_KEY, newEmail)
     setToken(newToken)
     setEmail(newEmail)
+    setIsNewUser(newUser)
   }, [])
+
+  const clearNewUser = useCallback(() => setIsNewUser(false), [])
 
   const clearAuth = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY)
     localStorage.removeItem(EMAIL_KEY)
     setToken(null)
     setEmail(null)
+    setIsNewUser(false)
   }, [])
 
   return (
-    <AuthContext.Provider value={{ token, email, isAuthenticated: !!token, isLoading, setAuth, clearAuth }}>
+    <AuthContext.Provider value={{ token, email, isAuthenticated: !!token, isLoading, isNewUser, setAuth, clearNewUser, clearAuth }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/screens/Auth.jsx
+++ b/src/screens/Auth.jsx
@@ -94,7 +94,7 @@ export default function Auth() {
       const res = isLogin
         ? await api.auth.login(email, password)
         : await api.auth.register(name, email, password)
-      setAuth(res.data.token, res.data.email)
+      setAuth(res.data.token, res.data.email, !isLogin)
       navigate(isLogin ? '/home' : '/onboarding')
     } catch (err) {
       setError(err.message)

--- a/src/screens/Onboarding.jsx
+++ b/src/screens/Onboarding.jsx
@@ -1,16 +1,21 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Goals from './onboarding/Goals'
 import Supplement from './onboarding/Supplement'
 import Schedule from './onboarding/Schedule'
 import { api } from '../services/api'
+import { useAuth } from '../context/AuthContext'
 
 const TOTAL_STEPS = 3
 
 export default function Onboarding() {
   const navigate = useNavigate()
+  const { clearNewUser } = useAuth()
   const [step, setStep] = useState(0)
   const [goalsData, setGoalsData] = useState(null)
+
+  // Clear the new-user flag so PublicRoute resumes normal redirect behaviour
+  useEffect(() => { clearNewUser() }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleGoalsNext(data) {
     setGoalsData(data)


### PR DESCRIPTION
## Summary
- Adds `isNewUser` flag to `AuthContext`
- `setAuth()` accepts optional `isNew` param (true during registration)
- `PublicRoute` skips its `/home` redirect when `isNewUser` is true
- `Onboarding` clears the flag on mount
- Fixes race condition where `PublicRoute` was overriding the `navigate('/onboarding')` call

## Test plan
- [ ] New user: register → lands on `/onboarding` Step 1 of 3
- [ ] Existing user: login → lands on `/home`
- [ ] Logged-in user navigating to `/auth` → redirected to `/home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)