### PR TITLE
chore: enforce PR-only flow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # recallth — Claude Code Instructions
 
+## Git / PR Rules — MANDATORY
+
+**NEVER push directly to main.** Branch protection enforces this — direct pushes will be rejected.
+
+Always follow this flow:
+```
+git checkout -b feat/issue-NNN-short-description
+# ... make changes ...
+git push -u origin <branch>
+gh pr create --title "..." --body "..."
+gh pr merge --auto --squash
+```
+
+Create the branch **before** touching any files. Name it `feat/issue-NNN-...` or `fix/issue-NNN-...`.
+
 ## Local Dev
 
 - Frontend: `http://localhost:5173`


### PR DESCRIPTION
## Summary
- Add mandatory PR flow rules to CLAUDE.md
- Branch protection (`enforce_admins`) now enabled — direct pushes to main rejected even for admin

## Test plan
- No functional changes
- Verify branch protection rejects direct push to main