### PR TITLE
fix: add missing aiGoals method to nutrition API service

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -124,6 +124,7 @@ export const api = {
       body: JSON.stringify(config),
     }),
     days: (year, month) => request(`/nutrition/days?year=${year}&month=${month}`),
+    aiGoals: (goals, conditions, language, mode, messages) => request('/nutrition/ai-goals', { method: 'POST', body: JSON.stringify({ goals, conditions, language, ...(mode ? { mode, messages } : {}) }) }),
     library: {
       list: () => request('/nutrition/library'),
       search: (q) => request(`/nutrition/library/search?q=${encodeURIComponent(q)}`),


### PR DESCRIPTION
Closes #218\n\nAdds the missing `aiGoals` method to `api.js` nutrition namespace. Backend endpoint `POST /nutrition/ai-goals` already existed but frontend had no way to call it.