### PR TITLE
fix: expanded food items respect nutrient filter

### DIFF
--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -716,15 +716,16 @@ function MealGroup({
             {isExpanded && (
               <div className="px-4 pb-3 flex flex-col gap-[6px] bg-sand/20">
                 {entry.foods?.length > 0 ? entry.foods.map((food, idx) => {
-                  const kcal = food.nutrients?.calories ?? food.calories
                   const protein = food.nutrients?.protein ?? food.protein
                   const carbs = food.nutrients?.carbs ?? food.carbs
                   const fat = food.nutrients?.fat ?? food.fat
+                  const kcal = food.nutrients?.calories ?? food.calories
                   const macros = [
                     protein != null && `${t('nutritionProtein')} ${formatNum(protein)}g`,
                     carbs != null && `${t('nutritionCarbs')} ${formatNum(carbs)}g`,
                     fat != null && `${t('nutritionFat')} ${formatNum(fat)}g`,
                   ].filter(Boolean).join(' · ')
+                  const foodMetricVal = getFoodMetric(food, logMetric)
                   return (
                     <div key={food.name ?? idx} className="flex items-start justify-between gap-3 py-[6px] border-b border-border/50 last:border-0">
                       <div className="min-w-0">
@@ -736,8 +737,8 @@ function MealGroup({
                         </p>
                         {macros && <p className="text-[11px] text-ink3 mt-[2px]">{macros}</p>}
                       </div>
-                      {kcal != null && (
-                        <p className="text-[12px] text-ink2 shrink-0 font-medium">{formatNum(kcal)} kcal</p>
+                      {(logMetric === 'calories' ? kcal != null : true) && (
+                        <p className="text-[12px] text-ink2 shrink-0 font-medium">{formatNum(foodMetricVal)} {metricCfg.unit}</p>
                       )}
                     </div>
                   )


### PR DESCRIPTION
## Summary
- Expanded food sub-items in the meal view now display the selected nutrient metric (protein/carbs/fat) instead of always showing kcal
- Uses `getFoodMetric(food, logMetric)` with `metricCfg.unit` for consistent display
- No regression when kcal filter is active

## Test plan
- [x] Select Protein filter → expand entry → each food shows protein value (e.g. 12.6 g)
- [x] Select Carbs filter → expand entry → each food shows carbs value
- [x] Select kcal → expand entry → shows kcal as before
- [x] Build passes (`npm run build`)
- [x] Playwright screenshot attached: individual items show 12.6 g / 5 g / 8 g when Protein is selected

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)