### PR TITLE
fix: /nutrition white screen — missing supplementRecs state and fetchRecommendations

### DIFF
--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -573,6 +573,8 @@ const TRANSLATIONS = {
     // ── Goal mode ────────────────────────────────────────────────────────
     nutritionGoalMode: 'Goal Mode',
     nutritionDidYouMean: 'Did you mean?',
+    nutritionRecTitle: 'Supplement Recommendations',
+    nutritionRecAllGood: 'Your supplements are covering all nutritional gaps today.',
   },
 
   'zh-TW': {
@@ -1130,6 +1132,8 @@ const TRANSLATIONS = {
     nutritionCollapse: '收起',
     nutritionGoalMode: '目標模式',
     nutritionDidYouMean: '是否指的是？',
+    nutritionRecTitle: '補充劑建議',
+    nutritionRecAllGood: '您今天的補充劑已涵蓋所有營養缺口。',
   },
 
   'zh-HK': {
@@ -1687,6 +1691,8 @@ const TRANSLATIONS = {
     nutritionCollapse: '收起',
     nutritionGoalMode: '目標模式',
     nutritionDidYouMean: '你係咪指？',
+    nutritionRecTitle: '補充劑建議',
+    nutritionRecAllGood: '你今日嘅補充劑已涵蓋所有營養缺口。',
   },
 }
 

--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -2208,6 +2208,22 @@ export default function NutritionTracker() {
     }
   }, [viewDate])
 
+  // ── Supplement recommendations ────────────────────────────────────────────
+  const [supplementRecs, setSupplementRecs] = useState(null)
+  const [recLoading, setRecLoading] = useState(false)
+
+  const fetchRecommendations = useCallback(async () => {
+    setRecLoading(true)
+    try {
+      const res = await api.nutrition.recommendations(viewDate)
+      setSupplementRecs(res?.data ?? res ?? null)
+    } catch {
+      setSupplementRecs(null)
+    } finally {
+      setRecLoading(false)
+    }
+  }, [viewDate])
+
   // ── Fetch selected day's log ──────────────────────────────────────────────
   const fetchEntries = useCallback(async () => {
     setEntriesLoading(true)
@@ -2227,7 +2243,8 @@ export default function NutritionTracker() {
   useEffect(() => {
     fetchSummary()
     fetchEntries()
-  }, [fetchSummary, fetchEntries])
+    fetchRecommendations()
+  }, [fetchSummary, fetchEntries, fetchRecommendations])
 
   // ── Delete with undo ─────────────────────────────────────────────────────
   function handleRequestDelete(entry) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -137,6 +137,7 @@ export const api = {
       body: JSON.stringify(config),
     }),
     days: (year, month) => request(`/nutrition/days?year=${year}&month=${month}`),
+    recommendations: (date) => request(`/nutrition/recommendations${date ? `?date=${date}` : ''}`),
     aiGoals: (goals, conditions, language, mode, messages) => request('/nutrition/ai-goals', { method: 'POST', body: JSON.stringify({ goals, conditions, language, ...(mode ? { mode, messages } : {}) }) }),
     library: {
       list: () => request('/nutrition/library'),


### PR DESCRIPTION
## Summary
- `/nutrition` showed a white screen due to `ReferenceError: recLoading is not defined` during render
- `supplementRecs`, `recLoading`, and `fetchRecommendations` were referenced in JSX (from the #57 supplement recs UI) but never declared

## Changes
- Added `supplementRecs` and `recLoading` useState declarations
- Added `fetchRecommendations` useCallback calling `GET /nutrition/recommendations?date=...`
- Added `api.nutrition.recommendations(date)` to api.js
- Added `nutritionRecTitle` / `nutritionRecAllGood` i18n keys in en, zh-TW, zh-HK
- Wired `fetchRecommendations` into the main data-fetch useEffect

## Test plan
- [ ] Navigate to /nutrition — page loads without white screen
- [ ] Supplement recommendations card appears when backend returns data

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)