### PR TITLE
fix: pass language to goals insights so AI responds in Cantonese

### DIFF
--- a/src/screens/Goals.jsx
+++ b/src/screens/Goals.jsx
@@ -78,7 +78,7 @@ function Spinner() {
 
 // ── Main component ───────────────────────────────────────────────────────────
 export default function Goals() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
 
   // ── Profile / goals state ────────────────────────────────────────────
   const [goals, setGoals] = useState([])
@@ -239,7 +239,7 @@ export default function Goals() {
     if (insightsCache[goalName]) return
     setLoadingInsights(goalName)
     try {
-      const res = await api.goals.insights({ goalName, goalNotes })
+      const res = await api.goals.insights({ goalName, goalNotes, language })
       const data = res?.data ?? res
       setInsightsCache(prev => ({ ...prev, [goalName]: data }))
     } catch {


### PR DESCRIPTION
Fixes #242

## What changed
- `Goals.jsx`: destructure `language` from `useLanguage()` and pass it to `api.goals.insights()`

## How to verify
1. Set language to 廣東話
2. Open a goal (e.g. Build Muscle) → tap "See supplement insights"
3. Descriptions and summary should appear in Cantonese