### PR TITLE
fix: add api.exercise namespace (#246 follow-up)

### DIFF
--- a/src/screens/ExerciseNew.jsx
+++ b/src/screens/ExerciseNew.jsx
@@ -87,7 +87,7 @@ export default function ExerciseNew() {
           }))
         if (validExercises.length > 0) payload.exercises = validExercises
       }
-      await api.post('/exercise', payload)
+      await api.exercise.create(payload)
       navigate('/exercise')
     } catch {
       setError('Failed to save. Please try again.')

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -146,4 +146,11 @@ export const api = {
       remove: (id) => request(`/nutrition/library/${id}`, { method: 'DELETE' }),
     },
   },
+  exercise: {
+    list: () => request('/exercise'),
+    create: (data) => request('/exercise', { method: 'POST', body: JSON.stringify(data) }),
+    get: (id) => request(`/exercise/${id}`),
+    update: (id, data) => request(`/exercise/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+    remove: (id) => request(`/exercise/${id}`, { method: 'DELETE' }),
+  },
 }


### PR DESCRIPTION
Fixes runtime error on /exercise page — api.exercise namespace was missing from api.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)