### PR TITLE
feat: include session ID in exercise page context (#263)

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -108,6 +108,7 @@ function intensityColor(intensity) {
 function buildExerciseSystemPrompt(session, name, t) {
   const lines = [
     `[Page context — Exercise Session]`,
+    `Session ID: ${session._id}`,
     `Activity: ${name}`,
     `Date: ${session.date}`,
     `Duration: ${session.durationMinutes} minutes`,


### PR DESCRIPTION
## Summary
- Add `Session ID: <id>` to the exercise session page context injected into FloatingChat
- Enables the AI to reference the session ID when generating `add_exercise_set` action buttons
- Part of #263 fix — backend PR merged separately

Closes wkliwk/recallth#263

🤖 Generated with [Claude Code](https://claude.com/claude-code)