### PR TITLE
feat(#269): AI add_exercise_set reflects immediately in ExerciseTable

### DIFF
--- a/src/components/FloatingChat.jsx
+++ b/src/components/FloatingChat.jsx
@@ -292,7 +292,10 @@ function ChatPanel({
         messageIndex,
         actionIndex,
       })
-      if (res.success) setAppliedActions((prev) => new Set([...prev, actionKey]))
+      if (res.success) {
+        setAppliedActions((prev) => new Set([...prev, actionKey]))
+        pageContext?.onActionApplied?.({ type: action.type, data: res.data })
+      }
     } catch { /* ignore */ }
   }
 

--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -546,6 +546,11 @@ export default function ExerciseDetail() {
       placeholder: t('chatExerciseContextPlaceholder'),
       data: session,
       systemPrompt: buildExerciseSystemPrompt(session, name, t),
+      onActionApplied: ({ type, data }) => {
+        if (type === 'add_exercise_set' && data?.updated) {
+          setSession(prev => ({ ...prev, exercises: data.updated }))
+        }
+      },
     })
   }, [session])
 
@@ -665,6 +670,7 @@ export default function ExerciseDetail() {
         {/* Gym exercises — inline editable table */}
         {(session.activityType === 'gym' || session.exercises?.length > 0) && (
           <ExerciseTable
+            key={`${session._id}-${(session.exercises ?? []).length}`}
             sessionId={session._id}
             initialExercises={session.exercises ?? []}
             onSaved={(updated) => setSession(updated)}


### PR DESCRIPTION
## Summary
- After confirming an AI `add_exercise_set` action, the new exercise row appears in ExerciseTable instantly — no page reload needed
- FloatingChat now calls `pageContext.onActionApplied` after any successful action
- ExerciseDetail registers the callback and updates `session.exercises` state
- ExerciseTable uses a `key` based on exercises count to remount when exercises are added

Closes #269

## Test plan
- [x] Build passes
- [x] Asked AI to add Deadlift 3×5 @ 120kg — confirmed action — row appeared immediately in table
- [x] Action button shows ✓ after confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)