### PR TITLE
fix(#276): remove duplicate Save button from EditSheet header

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -411,13 +411,7 @@ function EditSheet({ session, onClose, onSaved, t }) {
         <div className="flex items-center justify-between px-5 pt-5 pb-3 shrink-0">
           <button onClick={onClose} className="text-[14px] text-ink3 font-medium">{t('cancel')}</button>
           <p className="text-[16px] font-semibold text-ink1">{t('editSession')}</p>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="text-[14px] font-semibold text-orange disabled:opacity-50"
-          >
-            {saving ? t('saving') : t('save')}
-          </button>
+          <div className="w-10" />
         </div>
 
         {/* Scrollable form */}


### PR DESCRIPTION
## Summary
- Removed the small text Save link from EditSheet header (top-right)
- Only the sticky footer orange Save button remains
- Fixes user confusion where EditSheet appeared to auto-save

Closes #276

## Test plan
- [x] EditSheet header shows title only — no Save link on right
- [x] Sticky footer orange Save button present and functional
- [x] Cancel button in top-left still works
- [x] Build passes
- [x] Playwright screenshot confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)