### PR TITLE
fix: desktop exercise table column alignment (#288)

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -192,8 +192,8 @@ function ExerciseRow({ row, unit = 'kg', onSave, onDelete }) {
   const { label, chipCls, icon, iconBg } = TYPE_CONFIG[type] ?? TYPE_CONFIG.strength
 
   // shared classes
-  const bigM  = 'text-[16px] font-bold text-ink1 bg-transparent outline-none tabular-nums min-w-0'
-  const bigD  = 'text-[20px] font-bold text-ink1 bg-transparent outline-none tabular-nums text-right'
+  const bigM  = 'text-[16px] font-bold text-ink1 bg-transparent outline-none tabular-nums min-w-0 appearance-none'
+  const bigD  = 'text-[20px] font-bold text-ink1 bg-transparent outline-none tabular-nums text-right appearance-none'
   const uSm   = 'text-[12px] text-ink3/50 shrink-0'
 
   // Mobile number fields per type
@@ -246,7 +246,7 @@ function ExerciseRow({ row, unit = 'kg', onSave, onDelete }) {
         <input className={`${bigD} w-9`}  type="number" min="1" value={reps}   onChange={e => setReps(e.target.value)}   onBlur={handleBlur} onKeyDown={onKey} placeholder="—" />
       </div>
     )
-    return <span className="text-ink3/30 text-right pr-2 block">—</span>
+    return <div className="flex justify-end"><span className="text-ink3/30 text-[18px]">—</span></div>
   }
 
   // Desktop col 5: "Weight" (or duration/distance)


### PR DESCRIPTION
## Summary
- Changed `desktopMetrics()` fallback `—` from a `<span pr-2 text-right>` to `<div flex justify-end>` — eliminates the 8px padding offset that made the dash appear shifted left compared to strength row numbers
- Added `appearance-none` to `bigM` and `bigD` classes to suppress browser number-input spinner buttons, ensuring consistent text positioning across all inputs

## Test plan
- [x] Open a gym session with mixed Strength + Cardio rows on desktop ≥768px
- [x] Verify Sets × Reps column: all right-edges align (numbers and `—` dashes at same x-position)
- [x] Verify Weight column: all right-edges align
- [x] No regressions on mobile layout

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)