### PR TITLE
fix(#305): support nested bullet points in chat markdown renderer

### DIFF
--- a/src/components/FloatingChat.jsx
+++ b/src/components/FloatingChat.jsx
@@ -4,6 +4,7 @@ import { chatService } from '../services/chat'
 import { useLanguage } from '../context/LanguageContext'
 import { useAiUsage } from '../context/AiUsageContext'
 import { useChatPage } from '../context/ChatPageContext'
+import { renderMarkdown } from '../utils/renderMarkdown'
 
 function SparkleIcon({ size = 20, color = 'currentColor' }) {
   return (
@@ -13,74 +14,6 @@ function SparkleIcon({ size = 20, color = 'currentColor' }) {
   )
 }
 
-function renderInline(text, baseKey = 0) {
-  const parts = []
-  const regex = /(\*\*[^*\n]+\*\*|\*[^*\n]+\*|`[^`\n]+`)/g
-  let last = 0
-  let k = baseKey
-  let match
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > last) parts.push(text.slice(last, match.index))
-    const m = match[0]
-    if (m.startsWith('**')) parts.push(<strong key={k++}>{m.slice(2, -2)}</strong>)
-    else if (m.startsWith('*')) parts.push(<em key={k++}>{m.slice(1, -1)}</em>)
-    else if (m.startsWith('`')) parts.push(<code key={k++} className="bg-ink1/10 px-[3px] rounded text-[11.5px] font-mono">{m.slice(1, -1)}</code>)
-    last = match.index + m.length
-  }
-  if (last < text.length) parts.push(text.slice(last))
-  return parts
-}
-
-function renderMarkdown(text) {
-  if (!text) return null
-  const lines = text.split('\n')
-  const nodes = []
-  let listItems = []
-  let listOrdered = false
-  let k = 0
-
-  function flushList() {
-    if (!listItems.length) return
-    const Tag = listOrdered ? 'ol' : 'ul'
-    nodes.push(
-      <Tag key={k++} className={`${listOrdered ? 'list-decimal' : 'list-disc'} pl-5 my-1 space-y-0.5`}>
-        {listItems.map((item, i) => <li key={i}>{renderInline(item, i * 100)}</li>)}
-      </Tag>
-    )
-    listItems = []
-  }
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-    const trimmed = line.trim()
-
-    if (trimmed === '' || trimmed === '---' || trimmed === '___') {
-      flushList()
-      continue
-    }
-    if (trimmed.startsWith('### ')) {
-      flushList()
-      nodes.push(<p key={k++} className="font-semibold text-[13px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(4), k * 100)}</p>)
-    } else if (trimmed.startsWith('## ')) {
-      flushList()
-      nodes.push(<p key={k++} className="font-semibold text-[13.5px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(3), k * 100)}</p>)
-    } else if (trimmed.startsWith('# ')) {
-      flushList()
-      nodes.push(<p key={k++} className="font-bold text-[14px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(2), k * 100)}</p>)
-    } else if (/^[-*] /.test(trimmed)) {
-      listOrdered = false
-      listItems.push(trimmed.slice(2))
-    } else if (/^\d+\. /.test(trimmed)) {
-      listOrdered = true
-      listItems.push(trimmed.replace(/^\d+\. /, ''))
-    } else {
-      flushList()
-      nodes.push(<p key={k++} className="leading-[1.55]">{renderInline(trimmed, k * 100)}</p>)
-    }
-  }
-  flushList()
-  return <div className="flex flex-col gap-[3px]">{nodes}</div>
-}
 
 function TypingIndicator() {
   return (

--- a/src/screens/Chat.jsx
+++ b/src/screens/Chat.jsx
@@ -6,6 +6,7 @@ import ChatBubble from '../components/ChatBubble'
 import InputPill from '../components/InputPill'
 import { chatService } from '../services/chat'
 import { api } from '../services/api'
+import { renderMarkdown } from '../utils/renderMarkdown'
 
 // ── Typing indicator ─────────────────────────────────────────────────────────
 function TypingIndicator() {
@@ -526,7 +527,10 @@ export default function Chat() {
                 {msg.image && (
                   <img src={msg.image} alt="Attached" className="w-full max-w-[200px] rounded-[8px] mb-2" />
                 )}
-                <span className="whitespace-pre-wrap">{msg.text}</span>
+                {msg.type === 'ai'
+                  ? renderMarkdown(msg.text)
+                  : <span className="whitespace-pre-wrap">{msg.text}</span>
+                }
                 {msg.actions?.length > 0 && (
                   <div className="mt-3 pt-3 border-t border-border/50 flex flex-col gap-[6px]">
                     <span className="text-[11px] font-semibold text-ink2 uppercase tracking-wide">

--- a/src/utils/renderMarkdown.jsx
+++ b/src/utils/renderMarkdown.jsx
@@ -1,0 +1,105 @@
+function renderInline(text, baseKey = 0) {
+  const parts = []
+  const regex = /(\*\*[^*\n]+\*\*|\*[^*\n]+\*|`[^`\n]+`)/g
+  let last = 0
+  let k = baseKey
+  let match
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > last) parts.push(text.slice(last, match.index))
+    const m = match[0]
+    if (m.startsWith('**')) parts.push(<strong key={k++}>{m.slice(2, -2)}</strong>)
+    else if (m.startsWith('*')) parts.push(<em key={k++}>{m.slice(1, -1)}</em>)
+    else if (m.startsWith('`')) parts.push(<code key={k++} className="bg-ink1/10 px-[3px] rounded text-[11.5px] font-mono">{m.slice(1, -1)}</code>)
+    last = match.index + m.length
+  }
+  if (last < text.length) parts.push(text.slice(last))
+  return parts
+}
+
+export function renderMarkdown(text) {
+  if (!text) return null
+  const lines = text.split('\n')
+  const nodes = []
+  let listItems = [] // { depth, ordered, text }
+  let k = 0
+
+  function isListLine(line) {
+    return /^\s*[-*] /.test(line) || /^\s*\d+\. /.test(line)
+  }
+
+  function parseListItem(line) {
+    const indent = line.match(/^(\s*)/)[1].length
+    const ordered = /^\s*\d+\. /.test(line)
+    const text = line.replace(/^\s*(?:[-*]|\d+\.)\s+/, '')
+    return { depth: indent, ordered, text }
+  }
+
+  function buildList(items) {
+    if (!items.length) return null
+    const root = []
+    const stack = [{ depth: -1, children: root }]
+
+    for (const item of items) {
+      const node = { text: item.text, ordered: item.ordered, children: [] }
+      while (stack.length > 1 && stack[stack.length - 1].depth >= item.depth) {
+        stack.pop()
+      }
+      stack[stack.length - 1].children.push(node)
+      stack.push({ depth: item.depth, children: node.children })
+    }
+
+    function toReact(children, parentOrdered) {
+      if (!children.length) return null
+      const Tag = parentOrdered ? 'ol' : 'ul'
+      const cls = parentOrdered
+        ? 'list-decimal pl-5 my-0.5 space-y-0.5'
+        : 'list-disc pl-5 my-0.5 space-y-0.5'
+      return (
+        <Tag key={k++} className={cls}>
+          {children.map((n, i) => (
+            <li key={i}>
+              {renderInline(n.text, i * 100)}
+              {n.children.length > 0 && toReact(n.children, n.children[0].ordered)}
+            </li>
+          ))}
+        </Tag>
+      )
+    }
+
+    return toReact(root, root[0]?.ordered)
+  }
+
+  function flushList() {
+    if (!listItems.length) return
+    const node = buildList(listItems)
+    if (node) nodes.push(node)
+    listItems = []
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+
+    if (trimmed === '' || trimmed === '---' || trimmed === '___') {
+      flushList()
+      continue
+    }
+    if (trimmed.startsWith('### ')) {
+      flushList()
+      nodes.push(<p key={k++} className="font-semibold text-[13px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(4), k * 100)}</p>)
+    } else if (trimmed.startsWith('## ')) {
+      flushList()
+      nodes.push(<p key={k++} className="font-semibold text-[13.5px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(3), k * 100)}</p>)
+    } else if (trimmed.startsWith('# ')) {
+      flushList()
+      nodes.push(<p key={k++} className="font-bold text-[14px] mt-2 mb-0.5 leading-snug">{renderInline(trimmed.slice(2), k * 100)}</p>)
+    } else if (isListLine(line)) {
+      listItems.push(parseListItem(line))
+    } else {
+      flushList()
+      nodes.push(<p key={k++} className="leading-[1.55]">{renderInline(trimmed, k * 100)}</p>)
+    }
+  }
+  flushList()
+  return <div className="flex flex-col gap-[3px]">{nodes}</div>
+}


### PR DESCRIPTION
## Summary
- Extracted `renderMarkdown` + `renderInline` to `src/utils/renderMarkdown.jsx`
- New nested list parser: uses raw line indentation to detect depth, builds a recursive tree via a stack, renders as nested `<ul>`/`<ol>`
- `FloatingChat.jsx` updated to import from shared util
- `Chat.jsx` full page now also uses `renderMarkdown` for AI messages (previously plain text)

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)