### PR TITLE
feat(#315): planned sessions UI — real data, 開始 flow, plan_exercise action

### DIFF
--- a/src/components/FloatingChat.jsx
+++ b/src/components/FloatingChat.jsx
@@ -544,6 +544,7 @@ function ChatPanel({
                         {msg.actions.map((action, ai) => {
                           const actionKey = `${i}-${ai}`
                           const applied = appliedActions.has(actionKey)
+                          const isPlan = action.type === 'plan_exercise'
                           return (
                             <button
                               key={ai}
@@ -552,10 +553,12 @@ function ChatPanel({
                               className={`flex items-center gap-1.5 text-left text-[11px] rounded-[8px] px-2 py-[6px] transition-all cursor-pointer ${
                                 applied
                                   ? 'bg-[#D4ECD8] text-[#2C5A38]'
-                                  : 'bg-orange/10 text-orange hover:bg-orange/20'
+                                  : isPlan
+                                    ? 'bg-[#1976D2]/10 text-[#1565C0] hover:bg-[#1976D2]/20'
+                                    : 'bg-orange/10 text-orange hover:bg-orange/20'
                               }`}
                             >
-                              {applied ? '✓' : '+'}
+                              {applied ? '✓' : isPlan ? '📅' : '+'}
                               <span>{action.label}</span>
                             </button>
                           )

--- a/src/screens/Exercise.jsx
+++ b/src/screens/Exercise.jsx
@@ -268,8 +268,8 @@ function QuickActions({ sessions, openChat }) {
   )
 }
 
-// ── Planned session card (demo) ───────────────────────────────────────────────
-function PlannedSessionCard({ session, t }) {
+// ── Planned session card ──────────────────────────────────────────────────────
+function PlannedSessionCard({ session, onStart, t }) {
   const label = session.activityType === 'other' && session.activityLabel
     ? session.activityLabel
     : activityLabel(session.activityType, t)
@@ -290,7 +290,10 @@ function PlannedSessionCard({ session, t }) {
         )}
         {session.intensity && <IntensityBadge intensity={session.intensity} t={t} />}
       </div>
-      <button className="shrink-0 bg-orange text-white rounded-[8px] px-[10px] py-[5px] text-[12px] font-medium flex items-center gap-1 hover:bg-orange-dk transition-colors cursor-pointer">
+      <button
+        onClick={onStart}
+        className="shrink-0 bg-orange text-white rounded-[8px] px-[10px] py-[5px] text-[12px] font-medium flex items-center gap-1 hover:bg-orange-dk transition-colors cursor-pointer"
+      >
         <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"/></svg>
         開始
       </button>
@@ -378,15 +381,6 @@ function EmptyState({ onLog, t }) {
 }
 
 // ── Main screen ───────────────────────────────────────────────────────────────
-// Demo mock planned session — shows tomorrow's suggested workout
-const DEMO_PLANNED = {
-  _id: 'demo-plan-1',
-  activityType: 'running',
-  durationMinutes: 30,
-  intensity: 'easy',
-  status: 'planned',
-}
-
 export default function Exercise() {
   const navigate = useNavigate()
   const { t } = useLanguage()
@@ -412,7 +406,9 @@ export default function Exercise() {
     load()
   }, [])
 
-  const filtered = filter === 'all' ? sessions : sessions.filter(s => s.activityType === filter)
+  const planned = sessions.filter(s => s.status === 'planned')
+  const completed = sessions.filter(s => s.status !== 'planned')
+  const filtered = filter === 'all' ? completed : completed.filter(s => s.activityType === filter)
   const { thisWeek, lastWeek, older } = groupSessionsByWeek(filtered)
   const hasSessions = sessions.length > 0
 
@@ -454,15 +450,24 @@ export default function Exercise() {
 
         {!loading && !error && hasSessions && (
           <>
-            <WeeklySummary sessions={sessions} t={t} />
-            <QuickActions sessions={sessions} openChat={openChat} />
-            <FilterChips sessions={sessions} active={filter} onChange={setFilter} t={t} />
+            <WeeklySummary sessions={completed} t={t} />
+            <QuickActions sessions={completed} openChat={openChat} />
+            <FilterChips sessions={completed} active={filter} onChange={setFilter} t={t} />
 
-            {/* UPCOMING — demo mock planned session */}
-            <div className="flex flex-col gap-3">
-              <p className="text-[12px] font-medium text-ink3 uppercase tracking-wide px-1">即將到來</p>
-              <PlannedSessionCard session={DEMO_PLANNED} t={t} />
-            </div>
+            {/* UPCOMING — real planned sessions */}
+            {planned.length > 0 && (
+              <div className="flex flex-col gap-3">
+                <p className="text-[12px] font-medium text-ink3 uppercase tracking-wide px-1">即將到來</p>
+                {planned.map(s => (
+                  <PlannedSessionCard
+                    key={s._id}
+                    session={s}
+                    onStart={() => navigate(`/exercise/new?plan=${s._id}`)}
+                    t={t}
+                  />
+                ))}
+              </div>
+            )}
 
             {filtered.length === 0 ? (
               <p className="text-[13px] text-ink3 text-center py-8">{t('noSessionsForFilter')}</p>

--- a/src/screens/ExerciseNew.jsx
+++ b/src/screens/ExerciseNew.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from '../services/api'
 import { useLanguage } from '../context/LanguageContext'
 
@@ -40,6 +40,8 @@ function todayISO() {
 export default function ExerciseNew() {
   const navigate = useNavigate()
   const { t } = useLanguage()
+  const [searchParams] = useSearchParams()
+  const planId = searchParams.get('plan') // planned session to complete
 
   // AI input state
   const [text, setText] = useState('')
@@ -60,6 +62,22 @@ export default function ExerciseNew() {
 
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
+
+  // Pre-fill form from planned session
+  useEffect(() => {
+    if (!planId) return
+    api.exercise.get(planId).then(res => {
+      const s = res?.data ?? res
+      if (!s) return
+      setActivityType(s.activityType || 'gym')
+      setActivityLabel(s.activityLabel || '')
+      setDate(s.date || todayISO())
+      setDuration(s.durationMinutes ? String(s.durationMinutes) : '')
+      setIntensity(s.intensity || 'moderate')
+      setNotes(s.notes || '')
+      setShowManual(true)
+    }).catch(() => {})
+  }, [planId])
 
   async function handleParse() {
     if (!text.trim()) return
@@ -144,6 +162,10 @@ export default function ExerciseNew() {
     setSaving(true)
     try {
       await api.exercise.create(payload)
+      // Delete the planned session now that it's been completed
+      if (planId) {
+        await api.exercise.remove(planId).catch(() => {})
+      }
       navigate('/exercise')
     } catch {
       setSaveError('Failed to save. Please try again.')


### PR DESCRIPTION
## Summary
- Remove hardcoded `DEMO_PLANNED` mock; UPCOMING section shows real `status === 'planned'` sessions
- UPCOMING hidden when no planned sessions exist
- Completed sessions only shown in THIS WEEK / LAST WEEK / older
- `PlannedSessionCard` 開始 button → `/exercise/new?plan=:id`
- `ExerciseNew` reads `?plan=` param → pre-fills form from API → on save: creates completed session + deletes planned
- `plan_exercise` chat action styled in blue with 📅 icon (distinct from orange + actions)

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)