### PR TITLE
fix(#338): use pointerWithin collision detection for date chip drops

### DIFF
--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -7,6 +7,7 @@ import {
   MeasuringStrategy,
   PointerSensor,
   TouchSensor,
+  pointerWithin,
   useSensor,
   useSensors,
   useDroppable,
@@ -742,7 +743,7 @@ function DateDropChip({ date, viewDate, onSelect, hasRecord, isFuture }) {
         isFuture
           ? 'bg-white border-border text-ink4 cursor-not-allowed'
           : isOver
-            ? 'bg-orange border-orange text-white scale-105 shadow-md'
+            ? 'bg-orange border-orange text-white shadow-md'
             : isCurrentView
               ? 'bg-orange/10 border-orange/50 text-ink1'
               : 'bg-white border-border text-ink2 hover:border-orange/40 hover:bg-orange/5',
@@ -3045,7 +3046,7 @@ export default function NutritionTracker() {
               </div>
             </div>
 
-            <DndContext sensors={sensors} onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd} measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}>
+            <DndContext sensors={sensors} collisionDetection={pointerWithin} onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd} measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}>
               <DateDropStrip viewDate={viewDate} onSelectDate={setViewDate} todayStr={todayStr} refreshKey={calendarRefreshKey} />
               {entriesLoading ? (
                 <div className="flex flex-col gap-3"><Skeleton className="h-[90px]" /><Skeleton className="h-[90px]" /></div>
@@ -3650,6 +3651,7 @@ export default function NutritionTracker() {
               ) : (
                 <DndContext
                   sensors={sensors}
+                  collisionDetection={pointerWithin}
                   onDragStart={handleDragStart}
                   onDragOver={handleDragOver}
                   onDragEnd={handleDragEnd}


### PR DESCRIPTION
## Summary
- Switches both V2 and V1 DndContexts from default `rectIntersection` to `pointerWithin`
- `pointerWithin`: drop registers only when the cursor is directly over the chip (not just when the drag overlay rect overlaps it)
- Removes `scale-105` from the `isOver` chip style — the visual scale-up was making the chip appear larger than its actual droppable rect
- Meal-type drop targets still work correctly (large sections, pointer easily within them)

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)