### PR TITLE
fix(#343): close history drawer after delete in Chat page

### DIFF
--- a/src/screens/Chat.jsx
+++ b/src/screens/Chat.jsx
@@ -345,6 +345,7 @@ export default function Chat() {
       await api.chat.delete(id)
       setHistory((prev) => prev.filter((c) => c._id !== id))
       if (conversationId === id) handleNewChat()
+      setDrawerOpen(false)
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary
Same bug as FloatingChat — `Chat.jsx`'s `handleDelete` only called `handleNewChat()` when deleting the **active** conversation. For all other conversations, the drawer stayed open.

Fix: always call `setDrawerOpen(false)` after any successful delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)