### PR TITLE
feat(#356): quick AI chips + persistent side panel on ExerciseDetail

### DIFF
--- a/src/components/FloatingChat.jsx
+++ b/src/components/FloatingChat.jsx
@@ -159,6 +159,7 @@ function ChatPanel({
   appliedActions, setAppliedActions,
   contextInjected, setContextInjected,
   pendingSend, onPendingSendConsumed,
+  persistent,
 }) {
   const { t } = useLanguage()
   const { pathname } = useLocation()
@@ -198,7 +199,9 @@ function ChatPanel({
   }
 
   const panelStyle = {
-    width: window.innerWidth >= 768 ? panelWidth : '100%',
+    width: window.innerWidth >= 768
+      ? panelWidth
+      : persistent ? Math.min(360, window.innerWidth * 0.9) : '100%',
   }
 
   useEffect(() => {
@@ -405,19 +408,22 @@ function ChatPanel({
     }
   }
 
+  // Outer wrapper: persistent = no backdrop, transparent, underlying content stays interactive
+  const outerCls = persistent
+    ? 'fixed inset-0 z-[60] flex justify-end pointer-events-none'
+    : 'fixed inset-0 z-[60] flex justify-end'
+  const outerStyle = persistent ? {} : { background: 'rgba(42,34,26,0.25)' }
+  const outerClick = persistent ? undefined : (e) => e.target === e.currentTarget && onClose()
+  const innerCls = `h-full bg-white flex flex-col shadow-2xl relative${persistent ? ' pointer-events-auto' : ''}`
+
   // History view
   if (view === 'history') {
     return (
-      <div
-        className="fixed inset-0 z-[60] flex justify-end"
-        style={{ background: 'rgba(42,34,26,0.25)' }}
-        onClick={(e) => e.target === e.currentTarget && onClose()}
-      >
+      <div className={outerCls} style={outerStyle} onClick={outerClick}>
         <div
-          className="h-full bg-white flex flex-col shadow-2xl relative"
+          className={innerCls}
           style={{ animation: 'slideIn 0.22s ease-out', ...panelStyle }}
         >
-          {/* Resize handle — desktop only */}
           <div
             className="hidden md:block absolute left-0 top-0 bottom-0 w-2 cursor-col-resize group z-10 select-none"
             onPointerDown={handleResizePointerDown}
@@ -430,7 +436,6 @@ function ChatPanel({
             onNewChat={handleNewChat}
             activeConversationId={conversationId}
             onActiveDeleted={() => {
-              // Reset chat state but stay on history view
               setConversationId(null)
               setMessages([])
               setAppliedActions(new Set())
@@ -451,13 +456,9 @@ function ChatPanel({
 
   // Chat view
   return (
-    <div
-      className="fixed inset-0 z-[60] flex justify-end"
-      style={{ background: 'rgba(42,34,26,0.25)' }}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-    >
+    <div className={outerCls} style={outerStyle} onClick={outerClick}>
       <div
-        className="h-full bg-white flex flex-col shadow-2xl relative"
+        className={innerCls}
         style={{ animation: 'slideIn 0.22s ease-out', ...panelStyle }}
       >
         {/* Resize handle — desktop only */}
@@ -740,6 +741,7 @@ function ChatPanel({
 
 export default function FloatingChat() {
   const [open, setOpen] = useState(false)
+  const [persistent, setPersistent] = useState(false)
   const location = useLocation()
   const { pageContext, chatRequest, clearChatRequest } = useChatPage()
   const [pendingSend, setPendingSend] = useState(null)
@@ -761,6 +763,7 @@ export default function FloatingChat() {
     setMessages([])
     setAppliedActions(new Set())
     setContextInjected(false)
+    setPersistent(false)
   }, [location.pathname])
 
   // Open chat and queue a message when a quick action is triggered
@@ -772,6 +775,8 @@ export default function FloatingChat() {
     setAppliedActions(new Set())
     setContextInjected(false)
     setPendingSend(chatRequest.message)
+    // Persistent side panel on exercise detail pages
+    setPersistent(/^\/exercise\/.+/.test(location.pathname))
     clearChatRequest()
   }, [chatRequest])
 
@@ -829,7 +834,7 @@ export default function FloatingChat() {
       )}
       {open && (
         <ChatPanel
-          onClose={() => setOpen(false)}
+          onClose={() => { setOpen(false); setPersistent(false) }}
           pageContext={pageContext}
           conversationId={conversationId}
           setConversationId={setConversationId}
@@ -841,6 +846,7 @@ export default function FloatingChat() {
           setContextInjected={setContextInjected}
           pendingSend={pendingSend}
           onPendingSendConsumed={() => setPendingSend(null)}
+          persistent={persistent}
         />
       )}
     </>

--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -773,7 +773,7 @@ export default function ExerciseDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const { t } = useLanguage()
-  const { setChatContext, clearChatContext } = useChatPage()
+  const { setChatContext, clearChatContext, openChat } = useChatPage()
   const [session, setSession] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -909,6 +909,26 @@ export default function ExerciseDetail() {
               {intensityLabel(session.intensity, t)}
             </span>
           </div>
+        </div>
+
+        {/* Quick AI chips */}
+        <div className="flex flex-wrap gap-2">
+          {[
+            '分析今日表現',
+            '建議明日訓練',
+            '我最近嘅進度點？',
+          ].map((chip) => (
+            <button
+              key={chip}
+              onClick={() => openChat(chip)}
+              className="flex items-center gap-1.5 px-3.5 py-2 rounded-full bg-orange/10 text-orange text-[13px] font-medium hover:bg-orange/20 active:bg-orange/30 transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z"/>
+              </svg>
+              {chip}
+            </button>
+          ))}
         </div>
 
         {/* Stats row */}


### PR DESCRIPTION
## Summary
- Add 3 quick AI chips on ExerciseDetail: 分析今日表現 / 建議明日訓練 / 我最近嘅進度點？
- Chips auto-send to FloatingChat when tapped
- On `/exercise/:id`, chat panel opens in persistent mode — no backdrop, `pointer-events-none` on outer wrapper so exercise data stays fully interactive behind the panel
- Mobile: panel narrows to `min(360px, 90vw)` to keep data accessible

## Test plan
- [ ] Open any exercise detail → 3 chips visible below hero card
- [ ] Tap a chip → chat panel opens on right, message auto-sent
- [ ] Exercise data (table, inputs) still interactive while panel is open
- [ ] Close X on panel works; FAB reappears
- [ ] On other pages (nutrition, home), chat opens with normal backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)