### PR TITLE
feat(#359,#360): chip cache + regenerate + hero card stat fold

### DIFF
--- a/src/components/FloatingChat.jsx
+++ b/src/components/FloatingChat.jsx
@@ -160,6 +160,7 @@ function ChatPanel({
   contextInjected, setContextInjected,
   pendingSend, onPendingSendConsumed,
   persistent,
+  lastChipSent, onRegenerate,
 }) {
   const { t } = useLanguage()
   const { pathname } = useLocation()
@@ -482,6 +483,21 @@ function ChatPanel({
             </div>
           </div>
           <div className="flex items-center gap-1">
+            {/* Regenerate button — persistent mode only, when a chip was used and there are messages */}
+            {persistent && lastChipSent && messages.length > 0 && (
+              <button
+                onClick={onRegenerate}
+                className="w-8 h-8 rounded-full flex items-center justify-center hover:bg-orange/10 transition-colors text-ink3 hover:text-orange cursor-pointer"
+                aria-label="Regenerate analysis"
+                title="重新分析"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M23 4v6h-6"/>
+                  <path d="M1 20v-6h6"/>
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+                </svg>
+              </button>
+            )}
             {/* New chat button */}
             <button
               onClick={handleNewChat}
@@ -742,6 +758,7 @@ function ChatPanel({
 export default function FloatingChat() {
   const [open, setOpen] = useState(false)
   const [persistent, setPersistent] = useState(false)
+  const [lastChipSent, setLastChipSent] = useState(null)
   const location = useLocation()
   const { pageContext, chatRequest, clearChatRequest } = useChatPage()
   const [pendingSend, setPendingSend] = useState(null)
@@ -764,19 +781,32 @@ export default function FloatingChat() {
     setAppliedActions(new Set())
     setContextInjected(false)
     setPersistent(false)
+    setLastChipSent(null)
   }, [location.pathname])
 
   // Open chat and queue a message when a quick action is triggered
   useEffect(() => {
     if (!chatRequest) return
+    const isPersistentPage = /^\/exercise\/.+/.test(location.pathname)
+    // If this chip already has an answered response in the current conversation, just reopen
+    const alreadyAnswered = messages.some((m, i) =>
+      m.type === 'user' && m.text === chatRequest.message &&
+      messages[i + 1]?.type === 'ai' && !messages[i + 1]?.isError
+    )
+    if (alreadyAnswered && isPersistentPage) {
+      setOpen(true)
+      setPersistent(true)
+      clearChatRequest()
+      return
+    }
     setOpen(true)
     setConversationId(null)
     setMessages([])
     setAppliedActions(new Set())
     setContextInjected(false)
     setPendingSend(chatRequest.message)
-    // Persistent side panel on exercise detail pages
-    setPersistent(/^\/exercise\/.+/.test(location.pathname))
+    setPersistent(isPersistentPage)
+    if (isPersistentPage) setLastChipSent(chatRequest.message)
     clearChatRequest()
   }, [chatRequest])
 
@@ -847,6 +877,15 @@ export default function FloatingChat() {
           pendingSend={pendingSend}
           onPendingSendConsumed={() => setPendingSend(null)}
           persistent={persistent}
+          lastChipSent={lastChipSent}
+          onRegenerate={() => {
+            if (!lastChipSent) return
+            setConversationId(null)
+            setMessages([])
+            setAppliedActions(new Set())
+            setContextInjected(false)
+            setPendingSend(lastChipSent)
+          }}
         />
       )}
     </>

--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -905,9 +905,17 @@ export default function ExerciseDetail() {
           <div className="flex-1 min-w-0">
             <p className="text-[20px] font-semibold text-ink1 capitalize">{name}</p>
             <p className="text-[13px] text-ink3 mt-[2px]">{formatDate(session.date)}</p>
-            <span className={`inline-block mt-2 text-[12px] font-medium px-3 py-[3px] rounded-full capitalize ${intensityColor(session.intensity)}`}>
-              {intensityLabel(session.intensity, t)}
-            </span>
+            <div className="flex items-center gap-2 mt-2 flex-wrap">
+              <span className={`text-[12px] font-medium px-3 py-[3px] rounded-full capitalize ${intensityColor(session.intensity)}`}>
+                {intensityLabel(session.intensity, t)}
+              </span>
+              <span className="text-[11px] text-ink3">·</span>
+              <span className="text-[12px] font-medium text-ink2">{session.durationMinutes} min</span>
+              {session.distanceKm > 0 && (<>
+                <span className="text-[11px] text-ink3">·</span>
+                <span className="text-[12px] font-medium text-ink2">{session.distanceKm} km</span>
+              </>)}
+            </div>
           </div>
         </div>
 
@@ -929,22 +937,6 @@ export default function ExerciseDetail() {
               {chip}
             </button>
           ))}
-        </div>
-
-        {/* Stats row */}
-        <div className="grid grid-cols-2 gap-3">
-          <StatCard
-            icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 15"/></svg>}
-            label={t('duration')}
-            value={`${session.durationMinutes} min`}
-          />
-          {session.distanceKm > 0 && (
-            <StatCard
-              icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12h18M3 6l9-3 9 3M3 18l9 3 9-3"/></svg>}
-              label={t('distance')}
-              value={`${session.distanceKm} km`}
-            />
-          )}
         </div>
 
         {/* Gym exercises — inline editable table */}


### PR DESCRIPTION
## Summary
- **#360**: Remove isolated StatCard grid — duration + distance folded inline into hero card as `[Intense] · 75 min [· 5 km]`
- **#359**: Re-tapping same chip reopens existing conversation (no new API call); only caches successful non-error responses. Add ↺ Regenerate button in panel header for persistent mode.

## Test plan
- [ ] Hero card shows `Intense · 75 min` inline, no StatCard below
- [ ] Distance shows in hero card when present (running/cycling sessions)
- [ ] Tapping chip opens chat; re-tapping reopens without resetting (when response was successful)
- [ ] ↺ button visible in header after chip response; clicking resets + re-sends
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)