### PR TITLE
fix: ExerciseDetail footer polish — unsaved indicator + Add exercise button (#365)

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -471,15 +471,11 @@ function ExerciseTable({ sessionId, initialExercises, onSaved }) {
       <div className="border-t border-[#EDE8E0]">
         <button
           onClick={addRow}
-          className="w-full py-3 text-[13px] font-medium text-orange flex items-center justify-center gap-1.5 hover:bg-sand/30 transition-colors border-b border-[#EDE8E0]"
+          className="w-full py-3 mx-0 text-[13px] font-medium text-orange flex items-center justify-center gap-2 hover:bg-sand/30 active:bg-sand/50 transition-colors border-b border-dashed border-[#DDD8CE]"
         >
-          <span className="text-[17px] leading-none font-light">+</span> Add exercise
+          <span className="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[14px] leading-none font-light shrink-0">+</span>
+          Add exercise
         </button>
-        {dirty && saveState === 'idle' && (
-          <p className="text-center text-[11px] font-semibold text-orange/70 py-1.5 tracking-wide">
-            ● Unsaved changes
-          </p>
-        )}
         <button
           onClick={() => saveRows(rows)}
           disabled={saving}
@@ -493,6 +489,7 @@ function ExerciseTable({ sessionId, initialExercises, onSaved }) {
           {saveState === 'saving' ? 'Saving…'
            : saveState === 'saved'  ? 'Saved ✓'
            : saveState === 'error'  ? 'Failed — try again'
+           : dirty ? '● Save changes'
            : 'Save changes'}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- **#365** Removed standalone "● Unsaved changes" floating text — was redundant and awkward between the two buttons
- **#365** Dot folded into the Save button label when dirty: `● Save changes` → full orange; clean state → muted `Save changes`
- **#365** "+ Add exercise" now has a circled `+` icon and dashed border separator for a more intentional affordance

## Test plan
- [x] Build passes
- [x] Clean state: Save button muted, no floating text
- [x] Dirty state: Save button shows `● Save changes` in full orange
- [x] Add exercise button has circled `+` icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)