### PR TITLE
fix: inject recent exercise history into chat context (#367)

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -105,7 +105,23 @@ function intensityColor(intensity) {
   return 'bg-sand text-ink2'
 }
 
-function buildExerciseSystemPrompt(session, name, t) {
+function buildSessionSummaryLine(s, nameLabel) {
+  const parts = [`${s.date} — ${nameLabel}, ${s.durationMinutes} min, ${s.intensity || 'unknown'}`]
+  if (s.distanceKm > 0) parts.push(`${s.distanceKm} km`)
+  if (s.exercises?.length > 0) {
+    const exSummary = s.exercises.slice(0, 5).map(ex => {
+      const t = normalizeExType(ex.type)
+      if (t === 'strength' || t === 'bodyweight') return `${ex.name} ${ex.sets}×${ex.reps}${ex.weightKg ? `@${ex.weightKg}kg` : ''}`
+      if (t === 'timed') return `${ex.name} ${ex.sets}×${Math.round((ex.durationMin || 0) * 60)}s`
+      if (t === 'cardio') return `${ex.name} ${ex.durationMin || 0}min${ex.distanceKm ? `/${ex.distanceKm}km` : ''}`
+      return ex.name
+    }).join(', ')
+    parts.push(`[${exSummary}${s.exercises.length > 5 ? ` +${s.exercises.length - 5} more` : ''}]`)
+  }
+  return parts.join(' | ')
+}
+
+function buildExerciseSystemPrompt(session, name, t, recentSessions) {
   const lines = [
     `[Page context — Exercise Session]`,
     `Session ID: ${session._id}`,
@@ -137,7 +153,20 @@ function buildExerciseSystemPrompt(session, name, t) {
     })
   }
   if (session.notes) lines.push(`Notes: ${session.notes}`)
-  lines.push(`\nThe user is viewing this specific exercise session and may ask questions about their performance, improvement, or the workout itself. Answer in the same language the user writes in.`)
+
+  // Inject recent history for progress questions
+  if (recentSessions?.length > 0) {
+    const others = recentSessions.filter(s => s._id !== session._id).slice(0, 19)
+    if (others.length > 0) {
+      lines.push(`\n[Recent exercise history — last ${others.length} sessions]`)
+      others.forEach(s => {
+        const label = s.activityLabel || s.activityType
+        lines.push(`  ${buildSessionSummaryLine(s, label)}`)
+      })
+    }
+  }
+
+  lines.push(`\nThe user is viewing this specific exercise session and may ask questions about their performance, progress over time, or the workout itself. Answer in the same language the user writes in.`)
   return lines.join('\n')
 }
 
@@ -789,16 +818,33 @@ export default function ExerciseDetail() {
   useEffect(() => {
     if (!session) return
     const name = activityLabel(session.activityType, session.activityLabel, t)
-    setChatContext({
-      title: name,
-      placeholder: t('chatExerciseContextPlaceholder'),
-      data: session,
-      systemPrompt: buildExerciseSystemPrompt(session, name, t),
-      onActionApplied: ({ type, data }) => {
-        if (type === 'add_exercise_set' && data?.updated) {
-          setSession(prev => ({ ...prev, exercises: data.updated }))
-        }
-      },
+    // Fetch recent history to enrich the chat context (best-effort — doesn't block)
+    api.exercise.list().then(res => {
+      const recent = (res.data ?? res) ?? []
+      setChatContext({
+        title: name,
+        placeholder: t('chatExerciseContextPlaceholder'),
+        data: session,
+        systemPrompt: buildExerciseSystemPrompt(session, name, t, recent),
+        onActionApplied: ({ type, data }) => {
+          if (type === 'add_exercise_set' && data?.updated) {
+            setSession(prev => ({ ...prev, exercises: data.updated }))
+          }
+        },
+      })
+    }).catch(() => {
+      // Fall back to current-session-only context if history fetch fails
+      setChatContext({
+        title: name,
+        placeholder: t('chatExerciseContextPlaceholder'),
+        data: session,
+        systemPrompt: buildExerciseSystemPrompt(session, name, t, []),
+        onActionApplied: ({ type, data }) => {
+          if (type === 'add_exercise_set' && data?.updated) {
+            setSession(prev => ({ ...prev, exercises: data.updated }))
+          }
+        },
+      })
     })
   }, [session])
 


### PR DESCRIPTION
## Summary
- **#367** `buildExerciseSystemPrompt` now accepts `recentSessions` and appends up to 19 other recent sessions as concise summary lines
- On session load, fetches `GET /exercise` (last 50, default) alongside current session. History is injected into the system prompt so the AI can answer "我最近嘅進度點？" with real data
- Falls back gracefully to current-session-only context if the history fetch fails (no breaking change)
- Each history line format: `2026-04-19 — gym, 60 min, moderate | [Squat 6×8@100kg, Deadlift 3×6@120kg]`

## ⚠️ Note
Full E2E UAT blocked by **expired `GOOGLE_GEMINI_API_KEY`** on the backend (pre-existing issue). The prompt construction was verified via unit test in Node. Please renew the API key in Railway env vars to complete verification.

## Test plan
- [x] Build passes
- [x] Prompt summary format verified manually (`node -e` test)
- [ ] E2E: tap "我最近嘅進度點？" → AI references specific sessions (blocked by API key expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)