### PR TITLE
fix: pre-fill exercises when opening a planned session

### DIFF
--- a/src/screens/ExerciseNew.jsx
+++ b/src/screens/ExerciseNew.jsx
@@ -75,6 +75,21 @@ export default function ExerciseNew() {
       setDuration(s.durationMinutes ? String(s.durationMinutes) : '')
       setIntensity(s.intensity || 'moderate')
       setNotes(s.notes || '')
+      if (Array.isArray(s.exercises) && s.exercises.length > 0) {
+        setExercises(s.exercises.map(ex => {
+          const type = ['strength', 'bodyweight', 'timed', 'cardio', 'session'].includes(ex.type) ? ex.type : 'strength'
+          return {
+            name: ex.name || '',
+            type,
+            sets: String(ex.sets || ''),
+            reps: String(ex.reps || ''),
+            weightKg: ex.weightKg ? String(ex.weightKg) : '',
+            durationSec: type === 'timed' ? String(Math.round((ex.durationMin || 0) * 60)) : '',
+            durationMin: (type === 'cardio' || type === 'session') ? String(ex.durationMin || '') : '',
+            distanceKm: type === 'cardio' ? String(ex.distanceKm || '') : '',
+          }
+        }))
+      }
       setShowManual(true)
     }).catch(() => {})
   }, [planId])


### PR DESCRIPTION
## Summary
When tapping 開始 on a planned session card, ExerciseNew now maps the session's `exercises` array into form state — so gym exercises (name, sets, reps, weight) are already filled in when the form opens.

## Before
Exercises were blank. User had to manually re-enter everything.

## After
All exercises from the AI plan are pre-populated in the form.

## Why it was missing
The pre-fill `useEffect` only set `activityType/duration/intensity/notes` — it never read the `exercises` field from the planned session.

Depends on wkliwk/recallth-backend#221 (exercises stored on planned sessions)
Closes wkliwk/recallth#376

🤖 Generated with [Claude Code](https://claude.com/claude-code)