### PR TITLE
fix: exercise AI section — tab layout + cache persists on close

### DIFF
--- a/src/screens/ExerciseDetail.jsx
+++ b/src/screens/ExerciseDetail.jsx
@@ -802,6 +802,7 @@ export default function ExerciseDetail() {
     suggest:  { text: localStorage.getItem(`exercise_suggest_${id}`) ?? null,    loading: false, error: null },
     progress: { text: localStorage.getItem(`exercise_progress_${id}`) ?? null,   loading: false, error: null },
   }))
+  const [activeTab, setActiveTab] = useState(null)
 
   useEffect(() => {
     async function load() {
@@ -873,9 +874,10 @@ export default function ExerciseDetail() {
     }
   }
 
-  function closeCard(type) {
-    setCards(prev => ({ ...prev, [type]: { text: null, loading: false, error: null } }))
-    localStorage.removeItem(CARD_CONFIG[type].storageKey)
+  function handleTabClick(type) {
+    if (activeTab === type) { setActiveTab(null); return }
+    setActiveTab(type)
+    fetchCard(type) // no-op if already cached
   }
 
   async function handleDelete() {
@@ -985,49 +987,64 @@ export default function ExerciseDetail() {
           </div>
         </div>
 
-        {/* Quick AI chips */}
+        {/* AI tabs */}
         <div className="flex flex-wrap gap-2">
           {[
-            { label: '分析今日表現',   type: 'analyze'  },
-            { label: '建議明日訓練',   type: 'suggest'  },
+            { label: '分析今日表現',    type: 'analyze'  },
+            { label: '建議明日訓練',    type: 'suggest'  },
             { label: '我最近嘅進度點？', type: 'progress' },
-          ].map(({ label, type }) => (
-            <button
-              key={type}
-              onClick={() => fetchCard(type)}
-              className="flex items-center gap-1.5 px-3.5 py-2 rounded-full bg-orange/10 text-orange text-[13px] font-medium hover:bg-orange/20 active:bg-orange/30 transition-colors"
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z"/>
-              </svg>
-              {label}
-            </button>
-          ))}
+          ].map(({ label, type }) => {
+            const isActive = activeTab === type
+            const hasCache = !!cards[type].text
+            const isLoading = cards[type].loading
+            return (
+              <button
+                key={type}
+                onClick={() => handleTabClick(type)}
+                className={`flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[13px] font-medium transition-colors ${
+                  isActive
+                    ? 'bg-orange text-white'
+                    : hasCache
+                      ? 'bg-orange/15 text-orange ring-1 ring-orange/40'
+                      : 'bg-orange/10 text-orange hover:bg-orange/20 active:bg-orange/30'
+                }`}
+              >
+                {isActive && isLoading ? (
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="animate-spin">
+                    <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+                  </svg>
+                ) : (
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z"/>
+                  </svg>
+                )}
+                {label}
+              </button>
+            )
+          })}
         </div>
 
-        {/* Inline AI cards */}
-        {Object.entries(CARD_CONFIG).map(([type, cfg]) => {
-          const card = cards[type]
-          if (!card.loading && !card.text && !card.error) return null
+        {/* AI content area — single panel for active tab */}
+        {activeTab && (() => {
+          const card = cards[activeTab]
+          const cfg = CARD_CONFIG[activeTab]
           return (
-            <div key={type} className="bg-white rounded-[16px] p-4 shadow-sm flex flex-col gap-3">
+            <div className="bg-white rounded-[16px] p-4 shadow-sm flex flex-col gap-3">
               <div className="flex items-start justify-between gap-2">
                 <span className="text-[12px] font-semibold text-ink3 uppercase tracking-wide">{cfg.label}</span>
                 <div className="flex items-center gap-2 -mt-0.5 -mr-0.5">
                   {!card.loading && (
-                    <button onClick={() => fetchCard(type, true)} title="重新生成" className="text-ink3 hover:text-ink1 transition-colors">
+                    <button onClick={() => fetchCard(activeTab, true)} title="重新生成" className="text-ink3 hover:text-ink1 transition-colors">
                       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                         <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
                       </svg>
                     </button>
                   )}
-                  {!card.loading && (
-                    <button onClick={() => closeCard(type)} className="text-ink3 hover:text-ink1 transition-colors">
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-                      </svg>
-                    </button>
-                  )}
+                  <button onClick={() => setActiveTab(null)} className="text-ink3 hover:text-ink1 transition-colors">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                  </button>
                 </div>
               </div>
               {card.loading && (
@@ -1051,7 +1068,7 @@ export default function ExerciseDetail() {
               {card.error && <p className="text-[13px] text-[#C05A28]">{card.error}</p>}
             </div>
           )
-        })}
+        })()}
 
         {/* Gym exercises — inline editable table */}
         {(session.activityType === 'gym' || session.exercises?.length > 0) && (


### PR DESCRIPTION
## Summary
- 3 chips replaced with 3 tabs — clicking a tab shows content in a single panel below (not stacked cards)
- Close (×) only hides the panel — **localStorage cache is preserved** so re-opening the tab is instant
- Refresh (↻) force re-fetches and updates cache  
- Tabs with cached content shown with a subtle ring indicator (even when not active)
- Active tab shows orange fill; loading spinner on active tab while fetching

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)