### PR TITLE
feat: URL auto-fill lookup in AdminFoodForm (#416)

### DIFF
--- a/src/screens/admin/AdminFoodForm.jsx
+++ b/src/screens/admin/AdminFoodForm.jsx
@@ -104,6 +104,11 @@ export default function AdminFoodForm() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
 
+  const [urlLookupUrl, setUrlLookupUrl] = useState('')
+  const [urlLooking, setUrlLooking] = useState(false)
+  const [urlLookupError, setUrlLookupError] = useState(null)
+  const [urlLookupSuccess, setUrlLookupSuccess] = useState(false)
+
   useEffect(() => {
     if (!isEdit) return
     api.admin.foodDb.get(id)
@@ -114,6 +119,24 @@ export default function AdminFoodForm() {
 
   const set = (field, value) => setForm(f => ({ ...f, [field]: value }))
   const setNutr = (field, value) => setForm(f => ({ ...f, per100g: { ...f.per100g, [field]: value } }))
+
+  const handleUrlLookup = async () => {
+    if (!urlLookupUrl.trim()) return
+    setUrlLooking(true)
+    setUrlLookupError(null)
+    setUrlLookupSuccess(false)
+    try {
+      const res = await api.admin.foodDb.urlLookup(urlLookupUrl.trim())
+      if (res.data) {
+        setForm(prev => ({ ...prev, ...toForm(res.data) }))
+        setUrlLookupSuccess(true)
+      }
+    } catch (e) {
+      setUrlLookupError(e.message)
+    } finally {
+      setUrlLooking(false)
+    }
+  }
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -148,6 +171,31 @@ export default function AdminFoodForm() {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {/* URL Auto-fill */}
+          <div className="bg-blue-50 border border-blue-100 rounded-xl p-5 space-y-3">
+            <h2 className="text-sm font-semibold text-blue-700">Auto-fill from URL</h2>
+            <p className="text-xs text-blue-500">Paste a product page URL (e.g. Open Food Facts, supermarket, brand site) to auto-populate all fields.</p>
+            <div className="flex gap-2">
+              <input
+                className="flex-1 border border-blue-200 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-400"
+                value={urlLookupUrl}
+                onChange={e => { setUrlLookupUrl(e.target.value); setUrlLookupSuccess(false); setUrlLookupError(null) }}
+                onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleUrlLookup())}
+                placeholder="https://www.openfoodfacts.org/product/..."
+              />
+              <button
+                type="button"
+                onClick={handleUrlLookup}
+                disabled={urlLooking || !urlLookupUrl.trim()}
+                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
+              >
+                {urlLooking ? 'Looking up...' : 'Lookup'}
+              </button>
+            </div>
+            {urlLookupError && <p className="text-red-500 text-xs">{urlLookupError}</p>}
+            {urlLookupSuccess && <p className="text-green-600 text-xs font-medium">Fields updated — review and save.</p>}
+          </div>
+
           {/* Basic Info */}
           <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
             <h2 className="text-sm font-semibold text-gray-700">Basic Info</h2>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -177,6 +177,7 @@ export const api = {
       remove: (id) => request(`/admin/food-db/${id}`, { method: 'DELETE' }),
       grabImage: (id) => request(`/admin/food-db/${id}/grab-image`, { method: 'POST' }),
       hardDelete: (id) => request(`/admin/food-db/${id}/hard`, { method: 'DELETE' }),
+      urlLookup: (url) => request('/admin/food-db/url-lookup', { method: 'POST', body: JSON.stringify({ url }) }),
     },
   },
 }


### PR DESCRIPTION
## Summary
- Adds a blue "Auto-fill from URL" section at the top of the Admin Food Form
- Paste any product URL (Open Food Facts, supermarket, brand site) and click Lookup
- All form fields (name, nutrition per 100g, serving, images, metadata) are pre-populated from the AI response
- Enter key also triggers the lookup
- Shows success/error feedback inline

## Test plan
- [ ] Navigate to `/admin/food-db/new`
- [ ] Paste a product URL (e.g. openfoodfacts.org product page)
- [ ] Click Lookup — fields should populate
- [ ] Verify nutrition values and name appear correctly
- [ ] Save the item and confirm it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)