### PR TITLE
fix: nutrition inputs step=any (#418)

### DIFF
--- a/src/screens/admin/AdminFoodForm.jsx
+++ b/src/screens/admin/AdminFoodForm.jsx
@@ -255,7 +255,7 @@ export default function AdminFoodForm() {
               ].map(({ key, label, required }) => (
                 <Field key={key} label={label} required={required}>
                   <input
-                    type="number" step="0.1" min="0"
+                    type="number" step="any" min="0"
                     className={inputCls}
                     value={form.per100g[key]}
                     onChange={e => setNutr(key, e.target.value)}


### PR DESCRIPTION
## Summary
- `step="0.1"` on nutrition number inputs rejected values like `0.032` with a browser validation error
- Changed to `step="any"` — admin form doesn't need step constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)