### PR TITLE
fix: resolve #463 - NutritionTracker date labels use t() instead of hardcoded English

### DIFF
--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -540,6 +540,7 @@ const TRANSLATIONS = {
     timeMinAgo: (n) => `${n}m ago`,
     timeHrAgo: (n) => `${n}h ago`,
     timeDaysAgo: (n) => `${n}d ago`,
+    timeToday: 'Today',
     timeYesterday: 'Yesterday',
     // ── Nutrition Tracker ────────────────────────────────────────────────
     nutritionTitle: 'Nutrition Tracker',
@@ -1198,6 +1199,7 @@ const TRANSLATIONS = {
     timeMinAgo: (n) => `${n}分鐘前`,
     timeHrAgo: (n) => `${n}小時前`,
     timeDaysAgo: (n) => `${n}天前`,
+    timeToday: '今天',
     timeYesterday: '昨天',
     // ── Nutrition Tracker ────────────────────────────────────────────────
     nutritionTitle: '營養追蹤',
@@ -1850,6 +1852,7 @@ const TRANSLATIONS = {
     timeMinAgo: (n) => `${n}分鐘前`,
     timeHrAgo: (n) => `${n}個鐘前`,
     timeDaysAgo: (n) => `${n}日前`,
+    timeToday: '今日',
     timeYesterday: '尋日',
     // ── Nutrition Tracker ────────────────────────────────────────────────
     nutritionTitle: '營養追蹤',

--- a/src/screens/NutritionTracker.jsx
+++ b/src/screens/NutritionTracker.jsx
@@ -35,12 +35,12 @@ function offsetDate(iso, days) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
-function formatDateLabel(iso) {
+function formatDateLabel(iso, t, language) {
   const today = todayISO()
-  if (iso === today) return 'Today'
-  if (iso === offsetDate(today, -1)) return 'Yesterday'
+  if (iso === today) return t('timeToday')
+  if (iso === offsetDate(today, -1)) return t('timeYesterday')
   const d = new Date(iso + 'T00:00:00')
-  return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
+  return d.toLocaleDateString(language, { weekday: 'short', day: 'numeric', month: 'short' })
 }
 
 // ── Skeleton primitive ────────────────────────────────────────────────────────
@@ -1569,7 +1569,7 @@ function CustomiseModal({ open, onClose, config, onSave, t }) {
 const DOW_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 
 function WeekStrip({ viewDate, onSelectDate, todayStr, refreshKey = 0 }) {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const [expanded, setExpanded] = useState(false)
 
   // Current month for record dot fetching
@@ -1669,7 +1669,7 @@ function WeekStrip({ viewDate, onSelectDate, todayStr, refreshKey = 0 }) {
       {/* Bottom row: date label + today + expand toggle */}
       <div className="flex items-center justify-between px-4 pb-2 max-w-[560px] mx-auto">
         <div className="flex items-center gap-2">
-          <p className="text-[11px] font-medium text-ink3">{viewDate === todayStr ? t('nutritionCalToday') : formatDateLabel(viewDate)}</p>
+          <p className="text-[11px] font-medium text-ink3">{viewDate === todayStr ? t('nutritionCalToday') : formatDateLabel(viewDate, t, language)}</p>
           {viewDate !== todayStr && (
             <button
               type="button"
@@ -2304,7 +2304,7 @@ export default function NutritionTracker() {
   // Allow browsing up to today+3 (matches drag-to-date strip range)
   const maxViewDate = offsetDate(todayStr, 3)
   const isAtMaxDate = viewDate >= maxViewDate
-  const dateLabel = isToday ? t('nutritionCalToday') : formatDateLabel(viewDate)
+  const dateLabel = isToday ? t('nutritionCalToday') : formatDateLabel(viewDate, t, language)
 
   // ── Feature flag ──────────────────────────────────────────────────────────
   const [useV2, setUseV2] = useState(() => getFlag('NUTRITION_V2'))


### PR DESCRIPTION
Closes #463

## Changes
- `formatDateLabel()` now accepts `t` and `language` params, uses `t('timeToday')` and `t('timeYesterday')` instead of hardcoded strings
- `toLocaleDateString` now uses the user's locale instead of hardcoded `'en-GB'`
- Added `timeToday` translation key to all three locales: `en` → `'Today'`, `zh-TW` → `'今天'`, `zh-HK` → `'今日'`
- Both call sites (`WeekStrip` and main `NutritionTracker`) updated to pass `t` and `language`

## DoD Verification
- [x] `formatDateLabel()` uses `t('timeToday')` and `t('timeYesterday')`
- [x] Translation keys added to en, zh-TW, zh-HK locales
- [x] Other dates use user locale via `toLocaleDateString(language, ...)`
- [x] `npm run build` passes ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_015TF2N7HVbuuVdCButYZCLM)_