### PR TITLE
fix: #461 - Cabinet "used up" filter button uses t() instead of hardcoded Chinese

### DIFF
--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -115,6 +115,7 @@ const TRANSLATIONS = {
     notThisOne: "Not this one — add manually",
     aiLookupNoMatch: 'No match found — add it manually.',
     recent: 'Recent',
+    cabinetFilterOutOfStock: 'Out of stock',
     interactionWarning: (n) => `${n} interaction${n !== 1 ? 's' : ''} detected in your cabinet`,
     // ── Cabinet Add ──────────────────────────────────────────────────────
     addTitle: 'Add Supplement',
@@ -792,6 +793,7 @@ const TRANSLATIONS = {
     notThisOne: '不是這個 — 手動新增',
     aiLookupNoMatch: '找不到結果 — 請手動新增。',
     recent: '最近',
+    cabinetFilterOutOfStock: '用完',
     interactionWarning: (n) => `您的藥箱中偵測到 ${n} 個交互作用`,
     addTitle: '新增補充品',
     addSubtitle: '追蹤新項目',
@@ -1456,6 +1458,7 @@ const TRANSLATIONS = {
     notThisOne: '唔係呢個 — 手動加',
     aiLookupNoMatch: '搵唔到結果 — 請手動加。',
     recent: '最近',
+    cabinetFilterOutOfStock: '用完',
     interactionWarning: (n) => `你嘅藥箱有 ${n} 個交互作用`,
     addTitle: '加補充品',
     addSubtitle: '追蹤新項目',

--- a/src/screens/Cabinet.jsx
+++ b/src/screens/Cabinet.jsx
@@ -243,7 +243,7 @@ export default function Cabinet() {
                     : 'bg-white border border-border text-ink3 hover:border-ink3/40'
                 }`}
               >
-                用完 {outOfStockCount}
+                {t('cabinetFilterOutOfStock')} {outOfStockCount}
               </button>
             )}
           </div>
@@ -326,7 +326,7 @@ export default function Cabinet() {
                     : 'bg-white border border-border text-ink3 hover:border-ink3/40'
                 }`}
               >
-                用完 {outOfStockCount}
+                {t('cabinetFilterOutOfStock')} {outOfStockCount}
               </button>
             )}
           </div>


### PR DESCRIPTION
Closes #461

## Changes
- `src/screens/Cabinet.jsx`: replace hardcoded `用完` with `{t('cabinetFilterOutOfStock')}` in both the mobile and desktop toolbars
- `src/context/LanguageContext.jsx`: add `cabinetFilterOutOfStock` key to all three locales
  - `en`: `'Out of stock'`
  - `zh-TW`: `'用完'`
  - `zh-HK`: `'用完'`

## DoD
- [x] Filter button uses `t('cabinetFilterOutOfStock')` — no hardcoded Chinese
- [x] Translation key added to en, zh-TW, zh-HK locale files
- [x] English users see "Out of stock"
- [x] zh-HK users see "用完"
- [x] `npm run build` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBTetHdnLjU61VNnoCbbDd)_