### PR TITLE
fix: resolve #455 - hide profile completeness nudge while stats are loading

### DIFF
--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -274,7 +274,7 @@ export default function Home() {
         </div>
 
         {/* ── Profile completeness nudge ── */}
-        {profileCompleteness !== null && profileCompleteness < 100 && (
+        {!statsLoading && profileCompleteness !== null && profileCompleteness < 100 && (
           <button
             onClick={() => navigateToChat(`Tell me about my ${firstMissingLabel}`)}
             className="w-full bg-orange-lt border border-orange-md rounded-[14px] px-4 py-4 mb-6 flex items-center gap-3 cursor-pointer hover:bg-orange-lt/80 transition-colors text-left"


### PR DESCRIPTION
Closes #455

Add `!statsLoading` guard to the profile completeness nudge so it cannot flash 0% or any stale value before the fetch resolves.

---
_Generated by [Claude Code](https://claude.ai/code/session_0121DqCg99ukKdwHHDpJKLBc)_