### PR TITLE
fix: #454 - Schedule dose check-off buttons wired to backend

### DIFF
--- a/src/screens/Schedule.jsx
+++ b/src/screens/Schedule.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../services/api'
 import { useLanguage } from '../context/LanguageContext'
@@ -16,7 +16,7 @@ const SLOT_COLOURS = [
 const SLOT_KEY_ORDER = ['morning', 'afternoon', 'evening', 'night', 'anytime']
 
 // ── Schedule block component ─────────────────────────────────────────────────
-function ScheduleBlock({ block }) {
+function ScheduleBlock({ block, doseLogs, toggling, onToggle }) {
   return (
     <div className="rounded-[14px] border overflow-hidden" style={{ borderColor: block.border }}>
       <div
@@ -27,27 +27,50 @@ function ScheduleBlock({ block }) {
         <span className="text-[12px] text-ink3">{block.time}</span>
       </div>
       <div className="bg-white divide-y divide-border">
-        {block.items.map((item, idx) => (
-          <div key={`${item.name}-${idx}`}>
-            <div className="flex items-center gap-3 px-4 py-[11px]">
-              <span className="w-2 h-2 rounded-full shrink-0" style={{ background: block.dot }} />
-              <div className="min-w-0">
-                <p className="text-[13px] font-medium text-ink1 truncate">{item.name}</p>
-                <p className="text-[11px] text-ink3">{item.dose}</p>
+        {block.items.map((item, idx) => {
+          const doseKey = `${item.id}:${block.key}`
+          const isChecked = !!doseLogs[doseKey]
+          const isToggling = toggling.has(doseKey)
+          return (
+            <div key={`${item.name}-${idx}`}>
+              <div className="flex items-center gap-3 px-4 py-[11px]">
+                <button
+                  onClick={() => onToggle(item, block.key, isChecked ? doseLogs[doseKey] : null)}
+                  disabled={isToggling || !item.id}
+                  className="shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors focus:outline-none"
+                  style={
+                    isChecked
+                      ? { backgroundColor: '#3D6B3D', borderColor: '#3D6B3D', opacity: isToggling ? 0.5 : 1 }
+                      : { backgroundColor: 'transparent', borderColor: '#C8BCA8', opacity: isToggling ? 0.5 : 1 }
+                  }
+                  aria-pressed={isChecked}
+                >
+                  {isChecked && (
+                    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                      <path d="M2 6l3 3 5-5" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </button>
+                <div className={`min-w-0 flex-1 transition-opacity ${isChecked ? 'opacity-40' : ''}`}>
+                  <p className={`text-[13px] font-medium text-ink1 truncate ${isChecked ? 'line-through' : ''}`}>
+                    {item.name}
+                  </p>
+                  <p className="text-[11px] text-ink3">{item.dose}</p>
+                </div>
               </div>
+              {item.conflict && (
+                <div className="flex items-center gap-2 px-4 py-[8px] bg-orange-lt border-t border-orange-md">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#C05A28" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/>
+                    <line x1="12" y1="17" x2="12.01" y2="17"/>
+                  </svg>
+                  <p className="text-[11px] text-orange-dk">{item.conflict}</p>
+                </div>
+              )}
             </div>
-            {item.conflict && (
-              <div className="flex items-center gap-2 px-4 py-[8px] bg-orange-lt border-t border-orange-md">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#C05A28" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-                  <line x1="12" y1="9" x2="12" y2="13"/>
-                  <line x1="12" y1="17" x2="12.01" y2="17"/>
-                </svg>
-                <p className="text-[11px] text-orange-dk">{item.conflict}</p>
-              </div>
-            )}
-          </div>
-        ))}
+          )
+        })}
         {block.conflicts && block.conflicts.length > 0 && (
           <div className="flex items-start gap-2 px-4 py-[10px] bg-orange-lt">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#C05A28" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 mt-[1px]" aria-hidden="true">
@@ -72,6 +95,8 @@ export default function Schedule() {
   const { t } = useLanguage()
   const [loading, setLoading] = useState(true)
   const [schedule, setSchedule] = useState([])
+  const [doseLogs, setDoseLogs] = useState({})
+  const [toggling, setToggling] = useState(new Set())
 
   const today = new Date().toLocaleDateString('en-GB', {
     weekday: 'long',
@@ -81,56 +106,101 @@ export default function Schedule() {
 
   useEffect(() => {
     let cancelled = false
+    const todayISO = new Date().toISOString().split('T')[0]
 
-    async function fetchSchedule() {
+    async function fetchData() {
       try {
-        const res = await api.cabinet.schedule()
+        const [scheduleRes, logsRes] = await Promise.allSettled([
+          api.cabinet.schedule(),
+          api.schedule.doseLogs(todayISO, todayISO),
+        ])
+
         if (cancelled) return
 
-        const raw = res?.data ?? {}
+        if (scheduleRes.status === 'fulfilled') {
+          const raw = scheduleRes.value?.data ?? {}
+          const scheduleObj = raw.schedule ?? raw
+          const SLOT_LABELS = { morning: t('slotMorning'), afternoon: t('slotAfternoon'), evening: t('slotEvening'), night: t('slotNight'), anytime: t('slotAnytime') }
 
-        // Backend returns { schedule: { morning: [...], ... } } or flat array
-        const scheduleObj = raw.schedule ?? raw
-        const SLOT_LABELS = { morning: t('slotMorning'), afternoon: t('slotAfternoon'), evening: t('slotEvening'), night: t('slotNight'), anytime: t('slotAnytime') }
+          if (scheduleObj && typeof scheduleObj === 'object' && !Array.isArray(scheduleObj)) {
+            const normalised = Object.entries(SLOT_LABELS)
+              .filter(([key]) => Array.isArray(scheduleObj[key]) && scheduleObj[key].length > 0)
+              .map(([key, label], idx) => {
+                const colours = SLOT_COLOURS[idx % SLOT_COLOURS.length]
+                const items = scheduleObj[key].map((it) => ({
+                  id: it.id ?? it._id ?? null,
+                  name: it.name ?? 'Unknown',
+                  dose: it.dosage ?? it.dose ?? '',
+                  conflict: it.conflict ?? null,
+                }))
+                return { key, label, time: '', bg: colours.bg, border: colours.border, dot: colours.dot, items, conflicts: [] }
+              })
 
-        if (scheduleObj && typeof scheduleObj === 'object' && !Array.isArray(scheduleObj)) {
-          const normalised = Object.entries(SLOT_LABELS)
-            .filter(([key]) => Array.isArray(scheduleObj[key]) && scheduleObj[key].length > 0)
-            .map(([key, label], idx) => {
-              const colours = SLOT_COLOURS[idx % SLOT_COLOURS.length]
-              const items = scheduleObj[key].map((it) => ({
-                name: it.name ?? 'Unknown',
-                dose: it.dosage ?? it.dose ?? '',
-                conflict: it.conflict ?? null,
-              }))
-              return { key, label, time: '', bg: colours.bg, border: colours.border, dot: colours.dot, items, conflicts: [] }
+            // Sort by canonical slot key order; unknowns go last
+            const sorted = [...normalised].sort((a, b) => {
+              const ai = SLOT_KEY_ORDER.indexOf(a.key)
+              const bi = SLOT_KEY_ORDER.indexOf(b.key)
+              const aIdx = ai === -1 ? SLOT_KEY_ORDER.length : ai
+              const bIdx = bi === -1 ? SLOT_KEY_ORDER.length : bi
+              return aIdx - bIdx
             })
 
-          // Sort by canonical slot key order; unknowns go last
-          const sorted = [...normalised].sort((a, b) => {
-            const ai = SLOT_KEY_ORDER.indexOf(a.key)
-            const bi = SLOT_KEY_ORDER.indexOf(b.key)
-            const aIdx = ai === -1 ? SLOT_KEY_ORDER.length : ai
-            const bIdx = bi === -1 ? SLOT_KEY_ORDER.length : bi
-            return aIdx - bIdx
-          })
-
-          setSchedule(sorted)
-        } else {
-          setSchedule([])
+            setSchedule(sorted)
+          } else {
+            setSchedule([])
+          }
         }
-      } catch {
-        setSchedule([])
+
+        if (logsRes.status === 'fulfilled') {
+          const logs = logsRes.value?.data ?? []
+          const logsMap = {}
+          for (const log of logs) {
+            const key = `${log.supplementId}:${log.slot ?? ''}`
+            logsMap[key] = log._id
+          }
+          setDoseLogs(logsMap)
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
 
-    fetchSchedule()
+    fetchData()
     return () => {
       cancelled = true
     }
   }, [t])
+
+  const toggleDose = useCallback(async (item, slotKey, existingLogId) => {
+    if (!item.id) return
+    const doseKey = `${item.id}:${slotKey}`
+    setToggling((prev) => new Set(prev).add(doseKey))
+    try {
+      if (existingLogId) {
+        await api.schedule.unlogDose(existingLogId)
+        setDoseLogs((prev) => {
+          const next = { ...prev }
+          delete next[doseKey]
+          return next
+        })
+      } else {
+        const res = await api.schedule.logDose({
+          supplementId: item.id,
+          supplementName: item.name,
+          slot: slotKey,
+        })
+        setDoseLogs((prev) => ({ ...prev, [doseKey]: res.data._id }))
+      }
+    } catch {
+      // leave UI state unchanged on error
+    } finally {
+      setToggling((prev) => {
+        const next = new Set(prev)
+        next.delete(doseKey)
+        return next
+      })
+    }
+  }, [])
 
   return (
     <div className="px-5 py-6 md:px-8 md:py-7 max-w-[960px]">
@@ -169,7 +239,13 @@ export default function Schedule() {
       ) : (
         <div className="flex flex-col gap-3">
           {schedule.map((block) => (
-            <ScheduleBlock key={`${block.label}-${block.time}`} block={block} />
+            <ScheduleBlock
+              key={`${block.label}-${block.time}`}
+              block={block}
+              doseLogs={doseLogs}
+              toggling={toggling}
+              onToggle={toggleDose}
+            />
           ))}
         </div>
       )}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -103,6 +103,11 @@ export const api = {
     streak: () => request('/intake/streak'),
     log: () => request('/intake/log', { method: 'POST' }),
   },
+  schedule: {
+    doseLogs: (from, to) => request(`/schedule/dose-logs?from=${from}&to=${to}`),
+    logDose: (data) => request('/schedule/log-dose', { method: 'POST', body: JSON.stringify(data) }),
+    unlogDose: (id) => request(`/schedule/log-dose/${id}`, { method: 'DELETE' }),
+  },
   bloodwork: {
     list: () => request('/bloodwork'),
     create: (data) => request('/bloodwork', { method: 'POST', body: JSON.stringify(data) }),


### PR DESCRIPTION
Closes #454

## Changes
- `src/services/api.js`: add `api.schedule.{doseLogs, logDose, unlogDose}` methods for the three schedule endpoints
- `src/screens/Schedule.jsx`:
  - Fetch today's dose logs in parallel with schedule on mount
  - Replace static coloured dot with interactive circular checkbox per dose
  - Checked doses: filled green circle + checkmark + strikethrough name + muted opacity
  - Toggle calls `POST /schedule/log-dose` (check) or `DELETE /schedule/log-dose/:id` (uncheck)
  - Optimistic UI: toggling state disables button while in-flight
  - Checked state persists on page refresh via `GET /schedule/dose-logs` fetch

## DoD
- [x] Tapping a dose checkbox calls `POST /schedule/log-dose` with `{ supplementId, supplementName, slot }`
- [x] A checked dose can be un-checked, calling `DELETE /schedule/log-dose/:id`
- [x] Checked state is visually distinct (filled green checkbox, strikethrough name, muted opacity)
- [x] Checked state persists on page refresh (loaded from backend on mount)
- [x] `npm run build` passes

https://claude.ai/code/session_013KczZY1d3bHZNeNh5eSsAC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KczZY1d3bHZNeNh5eSsAC)_