### PR TITLE
feat: batch #446 #441 #422 #430 — ingredient search, onboarding modal, Cantonese nutrition AI

### DIFF
--- a/src/screens/Cabinet.jsx
+++ b/src/screens/Cabinet.jsx
@@ -139,8 +139,37 @@ export default function Cabinet() {
 
   const outOfStockCount = supplements.filter((s) => s.outOfStock).length
 
+  // #446 — also search through ingredients list
+  function matchesSearch(s) {
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    if (s.name.toLowerCase().includes(q)) return true
+    // ingredients can be an array of strings or a single comma-separated string
+    if (Array.isArray(s.ingredients)) {
+      return s.ingredients.some((ing) => String(ing).toLowerCase().includes(q))
+    }
+    if (typeof s.ingredients === 'string' && s.ingredients) {
+      return s.ingredients.toLowerCase().includes(q)
+    }
+    return false
+  }
+
+  // Determine what field matched (for display note)
+  function matchedIngredient(s) {
+    if (!search.trim()) return null
+    if (s.name.toLowerCase().includes(search.toLowerCase())) return null
+    const q = search.toLowerCase()
+    if (Array.isArray(s.ingredients)) {
+      return s.ingredients.find((ing) => String(ing).toLowerCase().includes(q)) || null
+    }
+    if (typeof s.ingredients === 'string') {
+      return s.ingredients.split(',').map((x) => x.trim()).find((x) => x.toLowerCase().includes(q)) || null
+    }
+    return null
+  }
+
   const filtered = supplements
-    .filter((s) => s.name.toLowerCase().includes(search.toLowerCase()))
+    .filter(matchesSearch)
     .filter((s) => stockFilter === 'out' ? s.outOfStock : true)
     .sort((a, b) => {
       if (sortBy === 'brand') return (a.brand || '').localeCompare(b.brand || '')
@@ -490,6 +519,7 @@ export default function Cabinet() {
             const colors = getLetterColors(supp.name)
             const evidenceScore = evidenceMap[supp.name] || supp.evidenceScore
             const evidenceLevel = evidenceScore?.level
+            const ingMatch = matchedIngredient(supp)
 
             return (
               <div
@@ -509,6 +539,11 @@ export default function Cabinet() {
                   variant={viewMode}
                   outOfStock={!!supp.outOfStock}
                 />
+                {ingMatch && (
+                  <p className="text-[10px] text-ink3 mt-1 px-1 truncate">
+                    matched ingredient: <span className="font-medium text-orange">{ingMatch}</span>
+                  </p>
+                )}
               </div>
             )
           })

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -5,6 +5,120 @@ import { useAuth } from '../context/AuthContext'
 import { useLanguage } from '../context/LanguageContext'
 import { calcProfileCompleteness, getFirstMissingLabel } from '../utils/profileCompleteness'
 
+// ── #441 Onboarding welcome modal ────────────────────────────────────────────
+const ONBOARDED_KEY = 'recallth_onboarded'
+
+function OnboardingModal({ onDone }) {
+  const navigate = useNavigate()
+  const [step, setStep] = useState(0)
+
+  function finish() {
+    localStorage.setItem(ONBOARDED_KEY, 'true')
+    onDone()
+  }
+
+  const steps = [
+    {
+      icon: (
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#E07B4A" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z"/>
+        </svg>
+      ),
+      title: 'Welcome to Recallth',
+      body: 'Your personal AI health advisor — tracking supplements, nutrition, and your overall wellness in one place.',
+      cta: 'Next',
+      onCta: () => setStep(1),
+    },
+    {
+      icon: (
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#E07B4A" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>
+        </svg>
+      ),
+      title: 'Set up your health profile',
+      body: 'Tell us about your goals, conditions and lifestyle so your AI advisor can give personalised recommendations.',
+      cta: 'Go to Profile',
+      onCta: () => { finish(); navigate('/profile') },
+      skip: () => setStep(2),
+    },
+    {
+      icon: (
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#E07B4A" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"/>
+        </svg>
+      ),
+      title: 'Add your supplements',
+      body: 'Build your supplement cabinet and get AI-powered interaction checks, evidence scores, and a daily schedule.',
+      cta: 'Go to Cabinet',
+      onCta: () => { finish(); navigate('/cabinet') },
+      skip: finish,
+    },
+  ]
+
+  const current = steps[step]
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) finish() }}
+    >
+      <div className="bg-white rounded-t-[24px] sm:rounded-[20px] w-full sm:max-w-[400px] px-6 pt-8 pb-8 flex flex-col items-center gap-5 animate-slide-up">
+        {/* Step dots */}
+        <div className="flex gap-1.5">
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              className="rounded-full transition-all"
+              style={{
+                width: i === step ? 20 : 6,
+                height: 6,
+                background: i === step ? '#E07B4A' : '#E8DDD4',
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Icon */}
+        <div className="w-[72px] h-[72px] rounded-full bg-orange/10 flex items-center justify-center">
+          {current.icon}
+        </div>
+
+        {/* Text */}
+        <div className="text-center">
+          <h2 className="font-display text-[22px] text-ink1 mb-2">{current.title}</h2>
+          <p className="text-[14px] text-ink2 leading-relaxed">{current.body}</p>
+        </div>
+
+        {/* CTA */}
+        <button
+          onClick={current.onCta}
+          className="w-full rounded-pill bg-orange text-white text-[15px] font-semibold py-[13px] cursor-pointer hover:bg-orange/90 transition-colors"
+        >
+          {current.cta}
+        </button>
+
+        {/* Skip / Dismiss */}
+        {current.skip ? (
+          <button
+            onClick={current.skip}
+            className="text-[13px] text-ink3 cursor-pointer hover:text-ink2 transition-colors"
+          >
+            Skip for now
+          </button>
+        ) : (
+          <button
+            onClick={finish}
+            className="text-[13px] text-ink3 cursor-pointer hover:text-ink2 transition-colors"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ── Colour palette for schedule time slots ──────────────────────────────────
 const SLOT_COLOURS = [
   { bg: '#FDE8DE', border: '#E8C4B0', dot: '#E07B4A' },  // orange
@@ -83,6 +197,14 @@ export default function Home() {
   const displayName = email
     ? email.split('@')[0].charAt(0).toUpperCase() + email.split('@')[0].slice(1)
     : ''
+
+  // ── #441 Onboarding modal state ────────────────────────────────────────────
+  const [showOnboarding, setShowOnboarding] = useState(false)
+
+  useEffect(() => {
+    const done = localStorage.getItem(ONBOARDED_KEY)
+    if (!done) setShowOnboarding(true)
+  }, [])
 
   // ── State ──────────────────────────────────────────────────────────────────
   const [statsLoading, setStatsLoading] = useState(true)
@@ -504,6 +626,8 @@ export default function Home() {
           </div>
         </div>
 
+      {/* #441 — First-time user onboarding modal */}
+      {showOnboarding && <OnboardingModal onDone={() => setShowOnboarding(false)} />}
     </div>
   )
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -121,7 +121,15 @@ export const api = {
     update: (id, data) => request(`/nutrition/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
     remove: (id) => request(`/nutrition/${id}`, { method: 'DELETE' }),
     removeBatch: (ids) => Promise.all(ids.map((id) => request(`/nutrition/${id}`, { method: 'DELETE' }))),
-    aiParse: (text, category) => request('/nutrition/parse', { method: 'POST', body: JSON.stringify({ text, category }) }),
+    // #430 — pass languageHint so backend can handle Cantonese/Traditional Chinese food
+    aiParse: (text, category) => {
+      // Detect if the input contains Chinese characters → hint the backend
+      const hasChinese = /[一-鿿㐀-䶿]/.test(text)
+      const languageHint = hasChinese
+        ? 'This input may contain Cantonese or Traditional Chinese food names (e.g. Hong Kong dim sum: 腸粉, 蝦餃, 叉燒包, 雲吞麵). Please recognise these and return accurate nutrition estimates. If a food item is unrecognised, return a best-effort estimate with confidence: "low".'
+        : undefined
+      return request('/nutrition/parse', { method: 'POST', body: JSON.stringify({ text, category, ...(languageHint ? { languageHint } : {}) }) })
+    },
     search: (q) => request(`/nutrition/search?q=${encodeURIComponent(q)}`),
     foodDb: {
       search: (params) => {


### PR DESCRIPTION
## What
Four features shipped in one batch PR:

**#446 — Cabinet: search by ingredient**
Cabinet search now also scans the supplement's `ingredients` field (supports both array and comma-separated string). When a match is on an ingredient rather than the supplement name, a small note "matched ingredient: magnesium" appears beneath the card.

**#441 — Onboarding: welcome modal for new users**
First-time users (detected via `localStorage.getItem('recallth_onboarded')`) see a 3-step slide-up modal on the Home screen:
1. Welcome — your AI health advisor
2. Set up your health profile (CTA → /profile)
3. Add your supplements (CTA → /cabinet)
Dismissing or completing any step sets `localStorage.setItem('recallth_onboarded', 'true')`.

**#422 — Schedule: today's intake check-off**
Already fully implemented via the backend API (logDose/unlogDose) with checkbox UI, strikethrough + opacity styles, and toggling state. Confirmed working — no frontend changes needed.

**#430 — Nutrition AI: Cantonese food prompt improvement**
`api.nutrition.aiParse` now detects Chinese characters in the input text using a Unicode regex. When detected, a `languageHint` field is added to the POST body containing explicit instructions for the backend to handle Cantonese/Traditional Chinese food names (dim sum examples: 腸粉, 蝦餃, 叉燒包, 雲吞麵) and to fall back gracefully for unrecognised items.

## Why
Closes #446
Closes #441
Closes #422
Closes #430

## Acceptance Criteria
- [x] Cabinet search matches on ingredient names, not just supplement name
- [x] Ingredient match shows "matched ingredient: X" note under the card
- [x] New users see onboarding modal on first Home visit
- [x] Onboarding modal has 3 steps with CTAs to Profile and Cabinet
- [x] Modal dismissal/completion sets recallth_onboarded in localStorage
- [x] Schedule check-off renders checkboxes; checked items get strikethrough
- [x] Nutrition AI parse sends languageHint for Chinese-character input
- [x] npm run build passes

## Test Plan
1. Cabinet: Add a supplement with an ingredient list. Search by one of the ingredients — card should appear with the matched ingredient note.
2. Onboarding: Clear localStorage, navigate to /home — modal should appear. Complete or dismiss, then refresh — modal should not reappear.
3. Schedule: Navigate to /schedule — checkboxes appear next to each item. Tap to check — item gets strikethrough and dimmed style.
4. Nutrition AI: On /nutrition/add Describe tab, type "腸粉" and hit Analyse — request payload should include a languageHint field (inspect network tab).