### PR TITLE
fix: batch UX fixes #447 #442 #420 #421 #433

### DIFF
--- a/src/screens/Chat.jsx
+++ b/src/screens/Chat.jsx
@@ -235,6 +235,8 @@ export default function Chat() {
   const [appliedActions, setAppliedActions] = useState(new Set())
   const [pendingActions, setPendingActions] = useState(new Set())
   const [failedActions, setFailedActions] = useState(new Set())
+  const [actionToast, setActionToast] = useState(null) // { message, type: 'success' | 'error' }
+  const actionToastTimerRef = useRef(null)
   const [editingIndex, setEditingIndex] = useState(null)
   const [editingText, setEditingText] = useState('')
 
@@ -247,6 +249,10 @@ export default function Chat() {
   const autoSentRef = useRef(false)
 
   const active = messages.length > 0 || isTyping
+
+  useEffect(() => {
+    return () => clearTimeout(actionToastTimerRef.current)
+  }, [])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -399,6 +405,12 @@ export default function Chat() {
     }
   }
 
+  function showActionToast(message, type = 'success') {
+    clearTimeout(actionToastTimerRef.current)
+    setActionToast({ message, type })
+    actionToastTimerRef.current = setTimeout(() => setActionToast(null), 2500)
+  }
+
   const handleApplyAction = async (action, actionKey, messageIndex, actionIndex) => {
     if (appliedActions.has(actionKey) || pendingActions.has(actionKey)) return
     setPendingActions((prev) => new Set([...prev, actionKey]))
@@ -411,12 +423,15 @@ export default function Chat() {
       })
       if (res.success) {
         setAppliedActions((prev) => new Set([...prev, actionKey]))
+        showActionToast(`${action.label} ✓`)
       } else {
         setFailedActions((prev) => new Set([...prev, actionKey]))
+        showActionToast(t('chatApplyFailed') || 'Action failed — tap to retry', 'error')
         setTimeout(() => setFailedActions((prev) => { const n = new Set(prev); n.delete(actionKey); return n }), 3000)
       }
     } catch {
       setFailedActions((prev) => new Set([...prev, actionKey]))
+      showActionToast(t('chatApplyFailed') || 'Action failed — tap to retry', 'error')
       setTimeout(() => setFailedActions((prev) => { const n = new Set(prev); n.delete(actionKey); return n }), 3000)
     } finally {
       setPendingActions((prev) => { const n = new Set(prev); n.delete(actionKey); return n })
@@ -802,6 +817,21 @@ export default function Chat() {
         />
         <RateLimitBadge count={msgCount} />
       </div>
+
+      {/* ── Action toast ──────────────────────────────────────────────── */}
+      {actionToast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`fixed bottom-[130px] left-1/2 -translate-x-1/2 z-50 px-4 py-[10px] rounded-[12px] shadow-lg text-[13px] font-medium whitespace-nowrap pointer-events-none transition-opacity ${
+            actionToast.type === 'error'
+              ? 'bg-[#C05A28] text-white'
+              : 'bg-[#2C5A38] text-white'
+          }`}
+        >
+          {actionToast.message}
+        </div>
+      )}
 
       <HistoryDrawer
         open={drawerOpen}

--- a/src/screens/Goals.jsx
+++ b/src/screens/Goals.jsx
@@ -162,18 +162,29 @@ export default function Goals() {
 
   // ── Confirm save handler ─────────────────────────────────────────────
   async function handleConfirmSave() {
-    if (!interpretedGoals || interpretedGoals.length === 0) return
-
     setSaving(true)
     setSaveError('')
 
+    // Build a notes string from AI chips (if any) as supplementary context
+    const aiChipsNote = interpretedGoals && interpretedGoals.length > 0
+      ? interpretedGoals.map((g) => `${g.emoji ?? ''} ${g.name}`.trim()).join(', ')
+      : ''
+
+    // Verbatim user text is always the goal title
+    const verbatimText = inputText.trim()
+    if (!verbatimText) {
+      setSaving(false)
+      return
+    }
+
     try {
       const existingNames = goals.map((g) => (typeof g === 'string' ? g : g.name))
-      const newGoalObjects = interpretedGoals
-        .filter((g) => !existingNames.includes(g.name))
-        .map((g) => ({ name: g.name, emoji: g.emoji ?? '🎯', notes: '' }))
+      const newGoal = existingNames.includes(verbatimText)
+        ? null
+        : { name: verbatimText, emoji: '🎯', notes: aiChipsNote }
+
       const existingObjects = goals.map((g) => normaliseGoal(g))
-      const merged = [...existingObjects, ...newGoalObjects]
+      const merged = newGoal ? [...existingObjects, newGoal] : existingObjects
 
       await api.profile.update({ goals: { primary: merged } })
 
@@ -521,25 +532,34 @@ export default function Goals() {
       {/* ── AI interpretation result ── */}
       {interpretedGoals !== null && (
         <div className="rounded-[14px] border border-[#C5D8C5] bg-[#F0F7F0] px-5 py-4 mb-6">
-          <p className="text-[13px] font-semibold text-[#3D6B3D] mb-3">
+          <p className="text-[13px] font-semibold text-[#3D6B3D] mb-2">
             {t('goalsInterpretedTitle')}
           </p>
 
-          <div className="flex flex-wrap gap-2 mb-4">
-            {interpretedGoals.length === 0 ? (
-              <p className="text-[13px] text-ink2">{t('goalsExtractFailed')}</p>
-            ) : (
-              interpretedGoals.map((g) => (
-                <span
-                  key={g.name}
-                  className="inline-flex items-center gap-1.5 bg-white border border-[var(--color-border)] rounded-full px-3 py-1 text-[13px] font-medium text-ink1"
-                >
-                  <span aria-hidden="true">{g.emoji}</span>
-                  {g.name}
-                </span>
-              ))
-            )}
+          {/* Verbatim goal title — displayed prominently */}
+          <div className="mb-3 bg-white border border-[#C5D8C5] rounded-[10px] px-3 py-[9px]">
+            <p className="text-[11px] text-ink3 font-medium uppercase tracking-[0.06em] mb-[2px]">Your goal</p>
+            <p className="text-[14px] font-semibold text-ink1">{inputText.trim()}</p>
           </div>
+
+          {/* AI sub-goals as supplementary chips */}
+          {interpretedGoals.length > 0 && (
+            <div className="mb-4">
+              <p className="text-[11px] text-ink3 font-medium uppercase tracking-[0.06em] mb-2">AI breakdown (saved as notes)</p>
+              <div className="flex flex-wrap gap-2">
+                {interpretedGoals.map((g) => (
+                  <span
+                    key={g.name}
+                    className="inline-flex items-center gap-1.5 bg-white border border-[var(--color-border)] rounded-full px-3 py-1 text-[13px] font-medium text-ink2"
+                  >
+                    <span aria-hidden="true">{g.emoji}</span>
+                    {g.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
 
           {/* Save error */}
           {saveError && (
@@ -552,7 +572,7 @@ export default function Goals() {
             <button
               type="button"
               onClick={handleConfirmSave}
-              disabled={saving || interpretedGoals.length === 0}
+              disabled={saving}
               className="flex items-center gap-2 bg-orange text-white text-[13px] font-semibold rounded-[10px] px-4 py-[9px] hover:opacity-90 transition-opacity disabled:opacity-60 cursor-pointer"
             >
               {saving && <Spinner />}

--- a/src/screens/Profile.jsx
+++ b/src/screens/Profile.jsx
@@ -108,6 +108,94 @@ const ACTIVITY_OPTIONS = [
   { value: 'very_active', label: 'Very active (2x/day)' },
 ]
 
+const BLOOD_TYPE_OPTIONS = [
+  { value: 'A+',  label: 'A+' },
+  { value: 'A-',  label: 'A-' },
+  { value: 'B+',  label: 'B+' },
+  { value: 'B-',  label: 'B-' },
+  { value: 'AB+', label: 'AB+' },
+  { value: 'AB-', label: 'AB-' },
+  { value: 'O+',  label: 'O+' },
+  { value: 'O-',  label: 'O-' },
+]
+
+const DIET_TYPE_OPTIONS = [
+  { value: 'omnivore',     label: 'Omnivore' },
+  { value: 'vegetarian',   label: 'Vegetarian' },
+  { value: 'vegan',        label: 'Vegan' },
+  { value: 'pescatarian',  label: 'Pescatarian' },
+  { value: 'keto',         label: 'Keto' },
+  { value: 'paleo',        label: 'Paleo' },
+  { value: 'gluten_free',  label: 'Gluten-free' },
+]
+
+// ── Pill tag input for allergies ───────────────────────────────────────────
+function AllergyTagInput({ label, tags, onChange }) {
+  const [inputVal, setInputVal] = useState('')
+
+  function addTag(raw) {
+    const trimmed = raw.trim()
+    if (!trimmed) return
+    if (!tags.includes(trimmed)) {
+      onChange([...tags, trimmed])
+    }
+    setInputVal('')
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      addTag(inputVal)
+    } else if (e.key === 'Backspace' && inputVal === '' && tags.length > 0) {
+      onChange(tags.slice(0, -1))
+    }
+  }
+
+  function handleBlur() {
+    if (inputVal.trim()) addTag(inputVal)
+  }
+
+  function removeTag(tag) {
+    onChange(tags.filter((t) => t !== tag))
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[10px] uppercase tracking-[0.08em] text-ink3 font-medium">
+        {label}
+      </label>
+      <div className="min-h-[38px] flex flex-wrap gap-1.5 items-center bg-white border border-border-md rounded-[10px] px-2 py-[6px] focus-within:border-orange-md transition-colors">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 bg-orange/10 text-orange-dk border border-orange/20 rounded-full px-2 py-[2px] text-[12px] font-medium"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="text-orange-dk/60 hover:text-orange-dk transition-colors leading-none ml-[2px]"
+              aria-label={`Remove ${tag}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={inputVal}
+          onChange={(e) => setInputVal(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder={tags.length === 0 ? 'Type and press Enter or comma…' : ''}
+          className="flex-1 min-w-[100px] text-[13px] text-ink1 outline-none bg-transparent placeholder:text-ink4"
+        />
+      </div>
+      <p className="text-[10px] text-ink3">Press Enter or comma to add each allergy as a tag</p>
+    </div>
+  )
+}
+
 function EditActions({ saving, error, onSave, onCancel }) {
   const { t } = useLanguage()
   return (
@@ -214,6 +302,7 @@ function AboutSection({ data, onSave }) {
           <Field label={t('fieldWeight')} value={draft.weight} onChange={(v) => set('weight', v)} />
           <SelectField label={t('fieldGender')} value={draft.sex} onChange={(v) => set('sex', v)} options={SEX_OPTIONS} />
           <SelectField label={t('fieldActivityLevel')} value={draft.activityLevel} onChange={(v) => set('activityLevel', v)} options={ACTIVITY_OPTIONS} />
+          <SelectField label="Blood Type" value={draft.bloodType} onChange={(v) => set('bloodType', v)} options={BLOOD_TYPE_OPTIONS} />
           <EditActions saving={saving} error={error} onSave={save} onCancel={cancel} />
         </div>
       ) : (
@@ -223,6 +312,7 @@ function AboutSection({ data, onSave }) {
           <ReadRow label={t('fieldWeight')} value={data.weight} />
           <ReadRow label={t('fieldGender')} value={SEX_OPTIONS.find((o) => o.value === data.sex)?.label ?? data.sex} />
           <ReadRow label={t('fieldActivityLevel')} value={ACTIVITY_OPTIONS.find((o) => o.value === data.activityLevel)?.label ?? data.activityLevel} />
+          <ReadRow label="Blood Type" value={data.bloodType} />
         </div>
       )}
     </ProfileSection>
@@ -383,20 +473,27 @@ function DietSection({ data, onSave }) {
     >
       {editing ? (
         <div className="flex flex-col gap-3">
+          <SelectField
+            label="Diet Type"
+            value={draft.dietType}
+            onChange={(v) => set('dietType', v)}
+            options={DIET_TYPE_OPTIONS}
+          />
           <Field
             label={t('fieldRestrictions')}
             value={toCommaString(draft.restrictions)}
             onChange={(v) => set('restrictions', fromCommaString(v))}
           />
-          <Field
+          <AllergyTagInput
             label={t('fieldAllergies')}
-            value={toCommaString(draft.allergies)}
-            onChange={(v) => set('allergies', fromCommaString(v))}
+            tags={Array.isArray(draft.allergies) ? draft.allergies : []}
+            onChange={(tags) => set('allergies', tags)}
           />
           <EditActions saving={saving} error={error} onSave={save} onCancel={cancel} />
         </div>
       ) : (
         <div className="flex flex-col gap-2">
+          <ReadRow label="Diet Type" value={DIET_TYPE_OPTIONS.find((o) => o.value === data.dietType)?.label ?? data.dietType} />
           <ReadRow label={t('fieldRestrictions')} value={data.restrictions} />
           <ReadRow label={t('fieldAllergies')} value={data.allergies} />
         </div>
@@ -842,10 +939,10 @@ function ConditionsSection({ data, t }) {
 }
 
 // ── Empty state fallbacks ──────────────────────────────────────────────────
-const EMPTY_BODY       = { weight: '', height: '', age: '', sex: '', activityLevel: '' }
+const EMPTY_BODY       = { weight: '', height: '', age: '', sex: '', activityLevel: '', bloodType: '' }
 const EMPTY_GOALS      = { primary: [], primaryGoal: '' }
 const EMPTY_EXERCISE   = { frequency: '', type: '', fitnessLevel: '' }
-const EMPTY_DIET       = { restrictions: [], allergies: [] }
+const EMPTY_DIET       = { restrictions: [], allergies: [], dietType: '' }
 const EMPTY_SLEEP      = { hoursPerNight: '', issues: [] }
 const EMPTY_LIFESTYLE  = { stressLevel: '', smokingStatus: '', alcoholConsumption: '' }
 


### PR DESCRIPTION
## What
Batch fix for 5 UX issues across Profile, Goals, and Chat screens. Notifications (#447) and Progress (#433) were already correctly implemented in the codebase.

## Why
Closes #447
Closes #442
Closes #420
Closes #421
Closes #433

## Acceptance Criteria
- [x] #447 — Notifications reminder time picker uses native `<input type="time">` (verified correct in current code)
- [x] #442 — Profile: blood type dropdown (A+/A-/B+/B-/AB+/AB-/O+/O-) added to About section
- [x] #442 — Profile: diet type dropdown (Omnivore/Vegetarian/Vegan/Pescatarian/Keto/Paleo/Gluten-free) added to Diet section
- [x] #442 — Profile: allergies replaced with pill-based tag input (Enter or comma to add, backspace/× to remove)
- [x] #420 — Goals: verbatim user text saved as goal title; AI chips stored as notes; original text shown prominently before saving
- [x] #421 — Chat: success toast appears after action applied; error toast on failure; auto-dismisses after 2.5s
- [x] #433 — Progress chart: 5 evenly-spaced Y-axis grid lines (verified correct in current code)
- [x] `npm run build` passes

## Test Plan
1. Profile (#442): Profile > About me > Edit > verify Blood Type dropdown appears. Profile > Diet > Edit > verify Diet Type dropdown and allergy tag input (type allergy, press Enter, see pill appear).
2. Goals (#420): Type "Lose 5kg by August" > Interpret > see original text shown as "Your goal" in green panel > AI breakdown shown below as chips > Save > goal card shows verbatim text as name.
3. Chat (#421): In chat, get a response with quick actions > click an action button > see green toast "Action label ✓" at bottom of screen for ~2.5s.
4. Notifications (#447): Notifications > Add Reminder > verify native time picker opens on mobile tap.
5. Progress (#433): Add 2+ weight entries > see line chart with 5 horizontal dashed grid lines.